### PR TITLE
Fix DATABASE_URL empty string bug and auth test mock issues

### DIFF
--- a/blowing-off/tests/unit/test_auth.py
+++ b/blowing-off/tests/unit/test_auth.py
@@ -179,9 +179,18 @@ class TestAuthManager:
         mock_response = AsyncMock()
         mock_response.status = 401
 
-        with patch('aiohttp.ClientSession') as mock_session:
-            mock_session.return_value.__aenter__.return_value.post.return_value.__aenter__.return_value = mock_response
+        # Create proper async context manager mock
+        mock_post = AsyncMock()
+        mock_post.__aenter__.return_value = mock_response
+        mock_post.__aexit__.return_value = None
 
+        # Create session mock
+        mock_session_inst = AsyncMock()
+        mock_session_inst.__aenter__.return_value = mock_session_inst
+        # Make post a regular Mock (not AsyncMock) that returns the async context manager
+        mock_session_inst.post = Mock(return_value=mock_post)
+
+        with patch('aiohttp.ClientSession', return_value=mock_session_inst):
             result = await auth_manager.login_admin("wrong_password")
 
             assert result == False
@@ -190,9 +199,17 @@ class TestAuthManager:
     @pytest.mark.asyncio
     async def test_login_admin_network_error(self, auth_manager):
         """Test admin login with network error."""
-        with patch('aiohttp.ClientSession') as mock_session:
-            mock_session.return_value.__aenter__.return_value.post.side_effect = aiohttp.ClientError()
+        # Create a mock async context manager that raises on enter
+        mock_post = AsyncMock()
+        mock_post.__aenter__.side_effect = aiohttp.ClientError()
 
+        # Create session mock
+        mock_session_inst = AsyncMock()
+        mock_session_inst.__aenter__.return_value = mock_session_inst
+        # Make post a regular Mock (not AsyncMock) that returns the async context manager
+        mock_session_inst.post = Mock(return_value=mock_post)
+
+        with patch('aiohttp.ClientSession', return_value=mock_session_inst):
             result = await auth_manager.login_admin("admin_password")
 
             assert result == False

--- a/blowing-off/tests/unit/test_auth_async.py
+++ b/blowing-off/tests/unit/test_auth_async.py
@@ -83,10 +83,17 @@ class TestAuthManagerAsync:
     @pytest.mark.asyncio
     async def test_login_admin_network_error(self, auth_manager):
         """Test admin login with network error."""
-        mock_session = MagicMock()
-        mock_session.__aenter__.return_value.post.side_effect = aiohttp.ClientError()
+        # Create proper async context manager mock that raises on enter
+        mock_post = AsyncMock()
+        mock_post.__aenter__.side_effect = aiohttp.ClientError()
 
-        with patch('aiohttp.ClientSession', return_value=mock_session):
+        # Create session mock
+        mock_session_inst = AsyncMock()
+        mock_session_inst.__aenter__.return_value = mock_session_inst
+        # Make post a regular Mock (not AsyncMock) that returns the async context manager
+        mock_session_inst.post = MagicMock(return_value=mock_post)
+
+        with patch('aiohttp.ClientSession', return_value=mock_session_inst):
             result = await auth_manager.login_admin("admin_password")
 
             assert result is False
@@ -220,10 +227,17 @@ class TestAuthManagerAsync:
         auth_manager.token = "old-token"
         auth_manager.role = "admin"
 
-        mock_session = MagicMock()
-        mock_session.__aenter__.return_value.post.side_effect = aiohttp.ClientError()
+        # Create proper async context manager mock that raises on enter
+        mock_post = AsyncMock()
+        mock_post.__aenter__.side_effect = aiohttp.ClientError()
 
-        with patch('aiohttp.ClientSession', return_value=mock_session):
+        # Create session mock
+        mock_session_inst = AsyncMock()
+        mock_session_inst.__aenter__.return_value = mock_session_inst
+        # Make post a regular Mock (not AsyncMock) that returns the async context manager
+        mock_session_inst.post = MagicMock(return_value=mock_post)
+
+        with patch('aiohttp.ClientSession', return_value=mock_session_inst):
             result = await auth_manager.refresh_token()
 
             assert result is False
@@ -278,10 +292,17 @@ class TestAuthManagerAsync:
         auth_manager.role = "admin"
         auth_manager.token = "admin-token"
 
-        mock_session = MagicMock()
-        mock_session.__aenter__.return_value.post.side_effect = aiohttp.ClientError()
+        # Create proper async context manager mock that raises on enter
+        mock_post = AsyncMock()
+        mock_post.__aenter__.side_effect = aiohttp.ClientError()
 
-        with patch('aiohttp.ClientSession', return_value=mock_session):
+        # Create session mock
+        mock_session_inst = AsyncMock()
+        mock_session_inst.__aenter__.return_value = mock_session_inst
+        # Make post a regular Mock (not AsyncMock) that returns the async context manager
+        mock_session_inst.post = MagicMock(return_value=mock_post)
+
+        with patch('aiohttp.ClientSession', return_value=mock_session_inst):
             result = await auth_manager.generate_guest_qr()
 
             assert result is None

--- a/funkygibbon/populate_graph_db.py
+++ b/funkygibbon/populate_graph_db.py
@@ -27,7 +27,8 @@ from sqlalchemy import text
 from inbetweenies.models import Base, Entity, EntityType, SourceType, EntityRelationship, RelationshipType, Blob, BlobType, BlobStatus
 
 # Default database URL - can be overridden by environment variable
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite+aiosqlite:///./funkygibbon.db")
+# Use 'or' to handle empty string case
+DATABASE_URL = os.environ.get("DATABASE_URL") or "sqlite+aiosqlite:///./funkygibbon.db"
 
 
 class GraphPopulator:


### PR DESCRIPTION
## Summary

This PR fixes all test failures found during validation (5 failing tests → all 369 tests passing).

## Issues Fixed

### 1. DATABASE_URL Empty String Bug
**File:** `funkygibbon/populate_graph_db.py`

**Problem:** When `DATABASE_URL` environment variable is set but empty, `os.environ.get("DATABASE_URL", default)` returns the empty string instead of the default value, causing SQLAlchemy URL parsing to fail.

**Fix:** Changed to `os.environ.get("DATABASE_URL") or "sqlite+aiosqlite:///./funkygibbon.db"` to properly handle empty strings.

### 2. Auth Test Mock Issues (5 failures)
**Files:** `blowing-off/tests/unit/test_auth.py`, `blowing-off/tests/unit/test_auth_async.py`

**Problem:** Tests were setting `side_effect` or `return_value` on mocked `.post()` method, but `aiohttp.ClientSession().post()` returns an async context manager. The mocks were returning coroutines instead of properly structured async context managers, causing `TypeError: 'coroutine' object does not support the asynchronous context manager protocol`.

**Fix:** Changed `.post` from AsyncMock to regular Mock that returns a proper AsyncMock async context manager. This correctly mocks the `async with session.post(...)` pattern used in the code.

**Tests fixed:**
- `test_login_admin_failure`
- `test_login_admin_network_error` (both test files)
- `test_refresh_token_network_error`
- `test_generate_guest_qr_network_error`

## Testing

Ran full test suite before and after fixes:
- **Before:** 364 passed, 5 failed
- **After:** 369 passed, 0 failed ✓

All tests now pass successfully on Python 3.11.

## Additional Notes

These were issues in test code and environment handling, not production functionality. All core features were already working correctly.

🤖 Generated with Claude Code