### PR TITLE
security(auth): explicit test mode, fail-closed secrets, remove silent backdoor

### DIFF
--- a/funkygibbon/api/routers/auth.py
+++ b/funkygibbon/api/routers/auth.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any
 from datetime import timedelta
 import json
+import logging
 import os
 
 from ...auth import (
@@ -23,13 +24,44 @@ from ...auth import (
 router = APIRouter(prefix="/auth", tags=["authentication"])
 security = HTTPBearer()
 
-# Initialize managers (in production, these would be singleton instances)
+_logger = logging.getLogger("funkygibbon.auth")
+
+# --- Auth modes (explicit — replaces the old silent `password == "admin"` backdoor) ---
+# FUNKYGIBBON_TEST_MODE makes a *configured* test password grant admin, with a loud
+# banner; without it the server fails closed unless real secrets are configured
+# (e.g. via `funkygibbon setup-auth`).
+TEST_MODE = os.getenv("FUNKYGIBBON_TEST_MODE", "").strip().lower() in ("1", "true", "yes", "on")
+TEST_PASSWORD = os.getenv("FUNKYGIBBON_TEST_PASSWORD", "admin")
+_INSECURE_SECRETS = {"", "development-secret-key", "dev-secret-key-change-in-production"}
+
+
+def _resolve_jwt_secret() -> str:
+    """JWT signing secret, or fail closed — no hardcoded fallback. A real secret
+    must be configured unless FUNKYGIBBON_TEST_MODE is explicitly enabled."""
+    secret = (os.getenv("JWT_SECRET") or os.getenv("SECRET_KEY") or "").strip()
+    if secret in _INSECURE_SECRETS:
+        if TEST_MODE:
+            return "funkygibbon-TEST-MODE-secret-NOT-for-production"
+        raise RuntimeError(
+            "No JWT signing secret configured. Run `funkygibbon setup-auth` to set "
+            "JWT_SECRET, or set FUNKYGIBBON_TEST_MODE=true for trusted local/dev use."
+        )
+    return secret
+
+
+if TEST_MODE:
+    _logger.warning(
+        "⚠ FUNKYGIBBON_TEST_MODE ENABLED — a known test password grants admin and a "
+        "non-production JWT secret is in use. DO NOT use this in production."
+    )
+
+# Initialize managers (singletons for this process)
 password_manager = PasswordManager()
-token_manager = TokenManager(secret_key=os.getenv("JWT_SECRET", "development-secret-key"))
+token_manager = TokenManager(secret_key=_resolve_jwt_secret())
 qr_manager = QRCodeManager()
 
-# Load admin password hash from config
-# In production, this would come from a configuration file
+# Admin password hash (argon2). Empty + TEST_MODE → the configured test password is
+# accepted; empty + not TEST_MODE → admin login fails closed.
 ADMIN_PASSWORD_HASH = os.getenv("ADMIN_PASSWORD_HASH", "")
 
 
@@ -196,9 +228,19 @@ async def admin_login(
     request_info = get_request_info(request)
 
     try:
+        if not ADMIN_PASSWORD_HASH and not TEST_MODE:
+            # Fail closed: no admin hash configured and not in explicit test mode.
+            audit_logger.log_auth_attempt(
+                success=False, identifier=client_ip,
+                reason="admin auth not configured", request_info=request_info
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Admin authentication is not configured. Run `funkygibbon setup-auth`.",
+            )
         if not ADMIN_PASSWORD_HASH:
-            # For development/testing when no password is set
-            if login_request.password == "admin":
+            # TEST_MODE only: a *configured* test password grants admin (banner logged at startup).
+            if login_request.password == TEST_PASSWORD:
                 # Log successful authentication
                 audit_logger.log_auth_attempt(
                     success=True,

--- a/funkygibbon/auth/rate_limiter.py
+++ b/funkygibbon/auth/rate_limiter.py
@@ -11,6 +11,8 @@ from datetime import datetime, timedelta
 import asyncio
 from functools import wraps
 
+from fastapi import HTTPException
+
 
 class RateLimiter:
     """
@@ -222,7 +224,6 @@ def rate_limit_decorator(get_identifier):
             allowed, retry_after = auth_rate_limiter.check_rate_limit(identifier)
 
             if not allowed:
-                from fastapi import HTTPException
                 raise HTTPException(
                     status_code=429,
                     detail=f"Too many attempts. Try again in {retry_after} seconds.",

--- a/funkygibbon/conftest.py
+++ b/funkygibbon/conftest.py
@@ -25,6 +25,12 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from datetime import datetime, UTC
 
+# Tests run in explicit auth test-mode (a configured test password is accepted and
+# a non-production JWT secret is used). Set before importing funkygibbon so the
+# auth router resolves its mode at import time.
+import os
+os.environ.setdefault("FUNKYGIBBON_TEST_MODE", "true")
+
 from funkygibbon.database import Base
 from funkygibbon.models import Entity, EntityType, SourceType, EntityRelationship, RelationshipType
 

--- a/funkygibbon/tests/test_auth_hardening.py
+++ b/funkygibbon/tests/test_auth_hardening.py
@@ -1,0 +1,52 @@
+"""Regression tests for auth hardening: no silent backdoor, fail-closed secrets,
+explicit test mode. Auth modes resolve at import time, so each case runs in a
+fresh subprocess with controlled environment."""
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_PP = os.pathsep.join([os.path.join(_REPO, "inbetweenies"), os.path.join(_REPO, "funkygibbon")])
+_MODE_VARS = ("FUNKYGIBBON_TEST_MODE", "FUNKYGIBBON_TEST_PASSWORD", "JWT_SECRET",
+              "SECRET_KEY", "ADMIN_PASSWORD_HASH")
+
+
+def _run(env_extra, code):
+    env = {k: v for k, v in os.environ.items() if k not in _MODE_VARS}
+    env["PYTHONPATH"] = _PP
+    env.update(env_extra)
+    return subprocess.run([sys.executable, "-c", textwrap.dedent(code)],
+                          env=env, capture_output=True, text=True)
+
+
+def test_fail_closed_without_secret_or_test_mode():
+    """No JWT secret and no test mode → the auth module refuses to load."""
+    r = _run({}, "import funkygibbon.api.routers.auth")
+    assert r.returncode != 0
+    assert "No JWT signing secret" in (r.stderr + r.stdout)
+
+
+def test_no_silent_admin_backdoor_and_configured_test_password_works():
+    """In test mode a *configured* password grants admin; the old literal
+    'admin' backdoor no longer works unless it IS the configured password."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db = f.name
+    try:
+        code = """
+            from funkygibbon.api.app import create_app
+            from fastapi.testclient import TestClient
+            c = TestClient(create_app())
+            ok = c.post('/api/v1/auth/admin/login', json={'password': 's3cret-test-pw'}).status_code
+            backdoor = c.post('/api/v1/auth/admin/login', json={'password': 'admin'}).status_code
+            print('RESULT', ok, backdoor)
+        """
+        r = _run({"FUNKYGIBBON_TEST_MODE": "true",
+                  "FUNKYGIBBON_TEST_PASSWORD": "s3cret-test-pw",
+                  "FUNKYGIBBON_DB": db,
+                  "DATABASE_URL": f"sqlite+aiosqlite:///{db}"}, code)
+        assert "RESULT 200 401" in r.stdout, r.stdout + r.stderr
+    finally:
+        os.unlink(db)


### PR DESCRIPTION
## What

Auth hardening for funkygibbon. **This PR is auth-hardening only** — it does not yet attach auth to the data endpoints. Data routes (graph/mcp/sync/sync_metadata) remain open until the next PR wires `require_auth`/`require_admin` and updates the oook + blowing-off clients atomically so local use isn't locked out.

## Why

The code review found that admin login granted access via a silent `password == "admin"` backdoor whenever `ADMIN_PASSWORD_HASH` was unset, plus a hardcoded `development-secret-key` JWT fallback. Per the agreed plan we keep a **test-mode** password but make it **explicit/opt-in** and fail closed otherwise.

## Changes

- **Remove the silent backdoor.** Admin login now returns **503** when nothing is configured. A test password is accepted **only** under explicit `FUNKYGIBBON_TEST_MODE`, and only if it matches the configured `FUNKYGIBBON_TEST_PASSWORD`. A loud banner is logged at startup when test mode is on.
- **Remove the hardcoded JWT fallback.** The signing secret resolves from `JWT_SECRET`/`SECRET_KEY` or **fails closed at import** (`RuntimeError`) unless `FUNKYGIBBON_TEST_MODE` is set, in which case a clearly-named non-production secret is used.
- **Fix a pre-existing `UnboundLocalError`** in `auth/rate_limiter.py`: `HTTPException` was imported locally inside the decorator, shadowing the name in the `except HTTPException` handler so every rate-limited path crashed. Import moved to module level.
- **conftest.py**: default `FUNKYGIBBON_TEST_MODE=true` for the test suite (auth resolves its mode at import time).
- **New `test_auth_hardening.py`**: subprocess regression tests proving the server fails closed without a secret, and that the configured test password works while the old literal `"admin"` no longer does.

## Verification

Verified against a copy of the real local DB (97-entity graph intact):

| Case | Result |
|---|---|
| Configured test pw | 200 + token |
| Old backdoor `"admin"` | 401 |
| Wrong pw | 401 |
| Unconfigured (no test mode) | 503 |
| App import without a secret | RuntimeError (fail closed) |

Existing auth tests pass; new regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)