### PR TITLE
security(auth): setup-auth tool, .env loading, and client token support

### DIFF
--- a/funkygibbon/__init__.py
+++ b/funkygibbon/__init__.py
@@ -59,3 +59,9 @@ app = create_app()
 
 __version__ = "0.1.0"
 __author__ = "The Goodies Team"
+
+# Load a local .env into the process environment before any submodule reads
+# os.getenv at import time (e.g. the auth router resolving JWT_SECRET). Real
+# environment variables take precedence; this only fills in what is unset.
+from .env_loader import load_env_file as _load_env_file  # noqa: E402
+_load_env_file()

--- a/funkygibbon/api/app.py
+++ b/funkygibbon/api/app.py
@@ -66,12 +66,13 @@ response = client.get("/health")
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from ..config import settings
 from ..database import init_db
 from .routers import sync_metadata, graph, mcp, auth
+from .routers.auth import require_auth
 from . import sync as enhanced_sync
 from ..auth import auth_rate_limiter, audit_logger
 
@@ -120,13 +121,18 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    # Include routers
+    # Auth router stays public (login / guest verify handle their own checks).
     app.include_router(auth.router, prefix=f"{settings.api_prefix}", tags=["authentication"])
-    app.include_router(enhanced_sync.router, tags=["sync"])
-    app.include_router(sync_metadata.router, prefix=f"{settings.api_prefix}/sync-metadata", tags=["sync-metadata"])
+
+    # All data routers require a valid bearer token. Applied at include time so
+    # every current and future endpoint on these routers is protected by default
+    # (fail-safe: you can't add an endpoint here and forget to guard it).
+    protected = [Depends(require_auth)]
+    app.include_router(enhanced_sync.router, tags=["sync"], dependencies=protected)
+    app.include_router(sync_metadata.router, prefix=f"{settings.api_prefix}/sync-metadata", tags=["sync-metadata"], dependencies=protected)
     # Graph and MCP routers (primary functionality)
-    app.include_router(graph.router, prefix=f"{settings.api_prefix}", tags=["graph"])
-    app.include_router(mcp.router, prefix=f"{settings.api_prefix}", tags=["mcp"])
+    app.include_router(graph.router, prefix=f"{settings.api_prefix}", tags=["graph"], dependencies=protected)
+    app.include_router(mcp.router, prefix=f"{settings.api_prefix}", tags=["mcp"], dependencies=protected)
 
     @app.get("/")
     async def root():

--- a/funkygibbon/config.py
+++ b/funkygibbon/config.py
@@ -53,7 +53,11 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_file=".env",
-        env_file_encoding="utf-8"
+        env_file_encoding="utf-8",
+        # The .env also carries auth keys (JWT_SECRET, ADMIN_PASSWORD_HASH,
+        # FUNKYGIBBON_TEST_MODE, ...) consumed directly via os.getenv elsewhere.
+        # Ignore anything that is not a Settings field instead of erroring.
+        extra="ignore",
     )
 
     # Database

--- a/funkygibbon/env_loader.py
+++ b/funkygibbon/env_loader.py
@@ -1,0 +1,38 @@
+"""Minimal .env loader.
+
+The auth router and several other modules read configuration via ``os.getenv``
+at import time. Pydantic settings read ``.env`` for their own fields, but that
+does not populate ``os.environ``, so plain ``os.getenv`` calls never see it.
+This loads a ``.env`` file into the process environment early (from the package
+``__init__``) so a ``.env`` written by ``setup-auth`` is picked up by the server.
+
+Real environment variables always win: existing keys are never overwritten.
+No third-party dependency (python-dotenv is not guaranteed to be installed).
+"""
+
+import os
+from pathlib import Path
+
+
+def load_env_file(path: str = ".env") -> None:
+    """Load KEY=VALUE pairs from `path` into os.environ via setdefault.
+
+    Silently does nothing if the file is absent. Lines that are blank, comments
+    (`#`), or lack an `=` are skipped. Surrounding quotes on values are stripped.
+    A leading `export ` is tolerated.
+    """
+    env_path = Path(path)
+    if not env_path.is_file():
+        return
+
+    for raw in env_path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):]
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            os.environ.setdefault(key, value)

--- a/funkygibbon/setup_auth.py
+++ b/funkygibbon/setup_auth.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+FunkyGibbon - Authentication setup / migration
+
+Run as:  python -m funkygibbon.setup_auth [options]
+
+The installs historically ran with authentication unattached to the data
+endpoints. Once auth is wired (every data endpoint requires a bearer token),
+each install needs a one-time setup that:
+
+  1. Generates and persists a strong JWT signing secret (JWT_SECRET) in .env,
+     so tokens survive restarts. Re-running keeps the existing secret (so
+     previously issued tokens stay valid) unless --rotate-secret is given.
+  2. Configures *how* an admin authenticates — either a real admin password
+     (argon2 hash stored as ADMIN_PASSWORD_HASH) or explicit, opt-in test mode
+     (FUNKYGIBBON_TEST_MODE=true with a configured FUNKYGIBBON_TEST_PASSWORD).
+  3. Mints a long-lived admin token and writes it into the local client configs
+     (oook: ~/.oook/config.json, blowing-off: ./.blowingoff.json) so the CLIs
+     keep working against the now-protected server.
+
+It is idempotent and supports --dry-run. Rollback is simply restoring the prior
+.env / client config (or disabling auth by clearing the relevant keys).
+
+This script writes secrets to local files. It is intended for the trusted,
+local, single-house deployment described in the project docs.
+"""
+
+import argparse
+import json
+import os
+import secrets
+import sys
+from datetime import timedelta
+from pathlib import Path
+from typing import Dict, Optional
+
+# Ensure the package is importable when run as a plain script too.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from funkygibbon.auth import PasswordManager, TokenManager  # noqa: E402
+
+MANAGED_KEYS = (
+    "JWT_SECRET",
+    "ADMIN_PASSWORD_HASH",
+    "FUNKYGIBBON_TEST_MODE",
+    "FUNKYGIBBON_TEST_PASSWORD",
+    "FUNKYGIBBON_CLIENT_TOKEN",
+)
+
+
+# --------------------------------------------------------------------------- #
+# .env read / upsert (comment- and order-preserving)
+# --------------------------------------------------------------------------- #
+def read_env(path: Path) -> Dict[str, str]:
+    """Parse an .env file into a dict (best effort; ignores comments/blanks)."""
+    values: Dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):]
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def upsert_env(path: Path, updates: Dict[str, str]) -> str:
+    """Return new .env text with `updates` applied: existing keys edited in
+    place, new keys appended. Comments and unrelated lines are preserved."""
+    lines = path.read_text().splitlines() if path.is_file() else []
+    remaining = dict(updates)
+    out = []
+    for raw in lines:
+        stripped = raw.strip()
+        body = stripped[len("export "):] if stripped.startswith("export ") else stripped
+        key = body.partition("=")[0].strip() if "=" in body else None
+        if key and key in remaining:
+            out.append(f"{key}={remaining.pop(key)}")
+        else:
+            out.append(raw)
+    if remaining:
+        if out and out[-1].strip():
+            out.append("")
+        out.append("# Added by funkygibbon setup-auth")
+        for key, value in remaining.items():
+            out.append(f"{key}={value}")
+    return "\n".join(out) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# Client config writers
+# --------------------------------------------------------------------------- #
+def write_json_config(path: Path, updates: Dict[str, str], dry_run: bool) -> None:
+    """Merge `updates` into a JSON config file, creating parents as needed."""
+    existing: Dict[str, object] = {}
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text())
+        except ValueError:
+            existing = {}
+    existing.update(updates)
+    rendered = json.dumps(existing, indent=2) + "\n"
+    if dry_run:
+        print(f"  [dry-run] would write {path}")
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    print(f"  wrote {path}")
+
+
+# --------------------------------------------------------------------------- #
+# Core
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m funkygibbon.setup_auth",
+        description="Configure authentication for a FunkyGibbon install.",
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--admin-password", metavar="PASS",
+                      help="Set a real admin password (argon2-hashed into .env).")
+    mode.add_argument("--test-mode", action="store_true",
+                      help="Enable explicit, opt-in test mode (a known test password).")
+    p.add_argument("--test-password", metavar="PASS", default="admin",
+                   help="Password accepted in test mode (default: admin).")
+    p.add_argument("--server-url", default="http://localhost:8000",
+                   help="Server URL written into client configs.")
+    p.add_argument("--token-days", type=int, default=3650,
+                   help="Client token lifetime in days (default: 3650).")
+    p.add_argument("--rotate-secret", action="store_true",
+                   help="Regenerate JWT_SECRET (invalidates all existing tokens).")
+    p.add_argument("--rotate-token", action="store_true",
+                   help="Re-mint the client token even if one already exists.")
+    p.add_argument("--env-file", default=".env", help="Path to .env (default: .env).")
+    p.add_argument("--no-client-config", action="store_true",
+                   help="Do not write oook / blowing-off client configs.")
+    p.add_argument("--oook-config", default=os.path.expanduser("~/.oook/config.json"),
+                   help="oook config path.")
+    p.add_argument("--blowingoff-config", default=".blowingoff.json",
+                   help="blowing-off config path.")
+    p.add_argument("--print-token", action="store_true",
+                   help="Print the client token to stdout.")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Show what would change without writing anything.")
+    return p
+
+
+def run(argv: Optional[list] = None) -> int:
+    args = build_parser().parse_args(argv)
+    env_path = Path(args.env_file)
+    current = read_env(env_path)
+    pm = PasswordManager()
+
+    updates: Dict[str, str] = {}
+
+    # 1. JWT secret -------------------------------------------------------- #
+    secret = current.get("JWT_SECRET", "").strip()
+    insecure = {"", "development-secret-key", "dev-secret-key-change-in-production"}
+    if args.rotate_secret or secret in insecure:
+        secret = secrets.token_urlsafe(48)
+        updates["JWT_SECRET"] = secret
+        secret_action = "rotated" if args.rotate_secret else "generated"
+    else:
+        secret_action = "kept existing"
+
+    # 2. Auth mode --------------------------------------------------------- #
+    if args.test_mode:
+        updates["FUNKYGIBBON_TEST_MODE"] = "true"
+        updates["FUNKYGIBBON_TEST_PASSWORD"] = args.test_password
+        # Test-mode admin login only triggers when no hash is configured.
+        updates["ADMIN_PASSWORD_HASH"] = ""
+        mode_desc = f"test mode (password: {args.test_password!r})"
+    else:
+        strong, message = pm.check_password_strength(args.admin_password)
+        if not strong:
+            print(f"⚠ weak admin password: {message} (continuing anyway)", file=sys.stderr)
+        updates["ADMIN_PASSWORD_HASH"] = pm.hash_password(args.admin_password)
+        updates["FUNKYGIBBON_TEST_MODE"] = "false"
+        mode_desc = "admin password (argon2 hash)"
+
+    # 3. Client token ------------------------------------------------------ #
+    existing_token = current.get("FUNKYGIBBON_CLIENT_TOKEN", "").strip()
+    must_remint = args.rotate_token or args.rotate_secret or not existing_token
+    if must_remint:
+        token = TokenManager(secret_key=secret).create_token(
+            user_id="local-client",
+            role="admin",
+            permissions=["read", "write", "delete", "configure"],
+            expires_delta=timedelta(days=args.token_days),
+        )
+        updates["FUNKYGIBBON_CLIENT_TOKEN"] = token
+        token_action = f"minted ({args.token_days}d)"
+    else:
+        token = existing_token
+        token_action = "kept existing"
+
+    # --- Report + write --------------------------------------------------- #
+    print("FunkyGibbon auth setup")
+    print(f"  env file:     {env_path}")
+    print(f"  JWT secret:   {secret_action}")
+    print(f"  auth mode:    {mode_desc}")
+    print(f"  client token: {token_action}")
+    if args.print_token:
+        print(f"  TOKEN: {token}")
+
+    new_env = upsert_env(env_path, updates)
+    if args.dry_run:
+        print("\n[dry-run] .env would become:\n")
+        print("\n".join("    " + ln for ln in new_env.splitlines()))
+    else:
+        env_path.write_text(new_env)
+        try:
+            os.chmod(env_path, 0o600)
+        except OSError:
+            pass
+        print(f"  wrote {env_path}")
+
+    if not args.no_client_config:
+        print("client configs:")
+        write_json_config(Path(args.oook_config),
+                          {"server_url": args.server_url, "auth_token": token},
+                          args.dry_run)
+        write_json_config(Path(args.blowingoff_config),
+                          {"server_url": args.server_url, "auth_token": token,
+                           "client_id": "local", "db_path": "blowingoff.db"},
+                          args.dry_run)
+
+    print("\nNext: (re)start the server so it picks up .env, then verify:")
+    print(f"  curl -s -o /dev/null -w '%{{http_code}}' {args.server_url}/api/v1/graph/statistics   # expect 401/403")
+    print(f"  curl -s -o /dev/null -w '%{{http_code}}' -H 'Authorization: Bearer <token>' "
+          f"{args.server_url}/api/v1/graph/statistics   # expect 200")
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/funkygibbon/tests/integration/test_endpoint_auth.py
+++ b/funkygibbon/tests/integration/test_endpoint_auth.py
@@ -1,0 +1,102 @@
+"""Auth-enforcement tests for the data endpoints.
+
+These prove that authentication is actually *attached* to the data routers, not
+merely defined. Every protected endpoint must reject an unauthenticated request
+(401/403) and a request bearing a bogus token (401), and must accept a request
+carrying a valid bearer token (so wiring auth does not lock out legitimate local
+use). They are designed to be RED before auth is wired in app.py and GREEN after.
+
+A valid token is obtained through the real login flow: under FUNKYGIBBON_TEST_MODE
+(set by the top-level conftest) `POST /auth/admin/login` with the configured test
+password mints an admin JWT.
+"""
+
+import pytest
+
+API = "/api/v1"
+
+# Representative endpoints across every protected router. The point is coverage of
+# each router (graph / mcp / sync / sync-metadata) and both reads and writes — a
+# router-level dependency protects all of its routes, so one per router proves it.
+PROTECTED = [
+    ("GET", f"{API}/graph/entities"),
+    ("GET", f"{API}/graph/statistics"),
+    ("POST", f"{API}/graph/entities"),
+    ("GET", f"{API}/mcp/tools"),
+    ("GET", f"{API}/sync-metadata/"),
+    ("POST", f"{API}/sync-metadata/"),
+    ("GET", f"{API}/sync/status"),
+    ("POST", f"{API}/sync/"),
+]
+
+# Endpoints that should return a clean 200 for an authenticated read against an
+# empty test database (proves auth lets legitimate traffic through).
+READABLE = [
+    f"{API}/graph/entities",
+    f"{API}/graph/statistics",
+    f"{API}/mcp/tools",
+    f"{API}/sync-metadata/",
+]
+
+
+async def _send(client, method, path, headers=None):
+    if method == "GET":
+        return await client.get(path, headers=headers)
+    return await client.post(path, json={}, headers=headers)
+
+
+@pytest.fixture
+def bearer():
+    """Build an Authorization header dict from a token string."""
+    return lambda token: {"Authorization": f"Bearer {token}"}
+
+
+async def _login(client):
+    """Log in via the real admin login flow (test mode) and return the JWT."""
+    resp = await client.post(
+        f"{API}/auth/admin/login", json={"password": "admin"}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,path", PROTECTED)
+async def test_unauthenticated_request_is_rejected(async_client, method, path):
+    """No Authorization header → the endpoint must refuse before doing any work."""
+    resp = await _send(async_client, method, path)
+    assert resp.status_code in (401, 403), (
+        f"{method} {path} returned {resp.status_code}; expected 401/403 — "
+        f"auth is not attached to this router"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,path", PROTECTED)
+async def test_invalid_token_is_rejected(async_client, bearer, method, path):
+    """A malformed/forged bearer token → 401 Invalid or expired token."""
+    resp = await _send(async_client, method, path, headers=bearer("not-a-real-jwt"))
+    assert resp.status_code == 401, (
+        f"{method} {path} returned {resp.status_code} for a bogus token; expected 401"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method,path", PROTECTED)
+async def test_valid_token_passes_auth(async_client, bearer, method, path):
+    """A valid bearer token must clear the auth gate (never 401/403)."""
+    token = await _login(async_client)
+    resp = await _send(async_client, method, path, headers=bearer(token))
+    assert resp.status_code not in (401, 403), (
+        f"{method} {path} returned {resp.status_code} WITH a valid token — "
+        f"authenticated local use is being locked out"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", READABLE)
+async def test_authenticated_read_succeeds(async_client, bearer, path):
+    """Authenticated reads against an empty DB return 200, not just non-401."""
+    token = await _login(async_client)
+    resp = await async_client.get(path, headers=bearer(token))
+    assert resp.status_code == 200, f"GET {path} -> {resp.status_code}: {resp.text}"

--- a/funkygibbon/tests/test_setup_auth.py
+++ b/funkygibbon/tests/test_setup_auth.py
@@ -1,0 +1,76 @@
+"""Tests for `funkygibbon.setup_auth` — the auth setup/migration tool.
+
+Covers the .env upsert helpers, idempotency, secret/token rotation, and that the
+minted client token actually verifies against the persisted JWT secret.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from funkygibbon import setup_auth
+from funkygibbon.auth import TokenManager
+
+
+def test_upsert_preserves_comments_and_edits_in_place(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("# header comment\nDATABASE_URL=sqlite:///x.db\nJWT_SECRET=old\n")
+    new = setup_auth.upsert_env(env, {"JWT_SECRET": "new", "ADMIN_PASSWORD_HASH": "h"})
+    env.write_text(new)
+    parsed = setup_auth.read_env(env)
+    assert "# header comment" in new           # comment preserved
+    assert parsed["DATABASE_URL"] == "sqlite:///x.db"  # untouched
+    assert parsed["JWT_SECRET"] == "new"        # edited in place
+    assert parsed["ADMIN_PASSWORD_HASH"] == "h"  # appended
+    assert new.count("JWT_SECRET=") == 1         # not duplicated
+
+
+def _run(tmp_path, *extra):
+    env = tmp_path / ".env"
+    setup_auth.run([
+        "--env-file", str(env), "--no-client-config", *extra,
+    ])
+    return setup_auth.read_env(env)
+
+
+def test_test_mode_writes_managed_keys_and_working_token(tmp_path):
+    cfg = _run(tmp_path, "--test-mode", "--test-password", "letmein")
+    assert cfg["FUNKYGIBBON_TEST_MODE"] == "true"
+    assert cfg["FUNKYGIBBON_TEST_PASSWORD"] == "letmein"
+    assert cfg["ADMIN_PASSWORD_HASH"] == ""
+    assert cfg["JWT_SECRET"]
+    # The minted token must verify against the persisted secret as an admin.
+    payload = TokenManager(secret_key=cfg["JWT_SECRET"]).verify_token(
+        cfg["FUNKYGIBBON_CLIENT_TOKEN"]
+    )
+    assert payload and payload["role"] == "admin"
+
+
+def test_idempotent_rerun_keeps_secret_and_token(tmp_path):
+    first = _run(tmp_path, "--test-mode")
+    second = _run(tmp_path, "--test-mode")
+    assert second["JWT_SECRET"] == first["JWT_SECRET"]
+    assert second["FUNKYGIBBON_CLIENT_TOKEN"] == first["FUNKYGIBBON_CLIENT_TOKEN"]
+
+
+def test_rotate_secret_changes_secret_and_remints_token(tmp_path):
+    first = _run(tmp_path, "--test-mode")
+    rotated = _run(tmp_path, "--test-mode", "--rotate-secret")
+    assert rotated["JWT_SECRET"] != first["JWT_SECRET"]
+    assert rotated["FUNKYGIBBON_CLIENT_TOKEN"] != first["FUNKYGIBBON_CLIENT_TOKEN"]
+    # Old token no longer verifies under the new secret.
+    assert TokenManager(secret_key=rotated["JWT_SECRET"]).verify_token(
+        first["FUNKYGIBBON_CLIENT_TOKEN"]
+    ) is None
+
+
+def test_admin_password_mode_hashes_and_disables_test_mode(tmp_path):
+    cfg = _run(tmp_path, "--admin-password", "CorrectHorse9!xZ")
+    assert cfg["ADMIN_PASSWORD_HASH"].startswith("$argon2")
+    assert cfg["FUNKYGIBBON_TEST_MODE"] == "false"
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    env = tmp_path / ".env"
+    setup_auth.run(["--env-file", str(env), "--no-client-config", "--test-mode", "--dry-run"])
+    assert not env.exists()

--- a/oook/oook/cli.py
+++ b/oook/oook/cli.py
@@ -39,7 +39,9 @@ comprehensive interface to smart home system capabilities.
 """
 
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import click
@@ -52,13 +54,25 @@ from rich.panel import Panel
 
 console = Console()
 
+# Where `funkygibbon setup-auth` writes oook's server URL + bearer token.
+CONFIG_PATH = Path(os.path.expanduser("~/.oook/config.json"))
+
+
+def load_config() -> Dict[str, Any]:
+    """Read ~/.oook/config.json if present (written by `funkygibbon setup-auth`)."""
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except (FileNotFoundError, ValueError):
+        return {}
+
 
 class MCPClient:
     """Client for interacting with FunkyGibbon MCP server"""
 
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, auth_token: Optional[str] = None):
         self.base_url = base_url.rstrip('/')
-        self.client = httpx.Client(timeout=30.0)
+        headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else {}
+        self.client = httpx.Client(timeout=30.0, headers=headers)
 
     def list_tools(self) -> List[Dict[str, Any]]:
         """List available MCP tools"""
@@ -123,17 +137,30 @@ class MCPClient:
 
 
 @click.group()
-@click.option('--server-url', '-s', default='http://localhost:8000',
-              help='FunkyGibbon server URL')
+@click.option('--server-url', '-s', default=None,
+              help='FunkyGibbon server URL (default: config or http://localhost:8000)')
+@click.option('--auth-token', '-T', default=None,
+              help='Bearer token (default: $FUNKYGIBBON_AUTH_TOKEN or ~/.oook/config.json)')
 @click.pass_context
-def cli(ctx, server_url):
+def cli(ctx, server_url, auth_token):
     """Oook - CLI for testing FunkyGibbon MCP server
 
     This tool provides direct access to MCP tools and graph operations
     for development and testing purposes.
+
+    The server now requires authentication. Run `funkygibbon setup-auth` on the
+    server to mint a token and write ~/.oook/config.json, or pass --auth-token /
+    set $FUNKYGIBBON_AUTH_TOKEN.
     """
+    config = load_config()
+    # Precedence: explicit flag > environment > config file > built-in default.
+    server_url = server_url or os.environ.get('FUNKYGIBBON_SERVER_URL') \
+        or config.get('server_url') or 'http://localhost:8000'
+    auth_token = auth_token or os.environ.get('FUNKYGIBBON_AUTH_TOKEN') \
+        or config.get('auth_token')
+
     ctx.ensure_object(dict)
-    ctx.obj['client'] = MCPClient(server_url)
+    ctx.obj['client'] = MCPClient(server_url, auth_token=auth_token)
 
 
 @cli.command()


### PR DESCRIPTION
Stacked on #32 → #31. Review/merge #31, then #32, then this. Base retargets automatically as each merges.

## What

The companion to the data-endpoint auth wiring (#32). It makes the wiring **safe to deploy** by (a) giving each install a one-time, idempotent auth setup and (b) teaching the CLIs to send a token.

## Pieces

- **`funkygibbon/setup_auth.py` (new)** — `python -m funkygibbon.setup_auth`:
  - Generates + persists a strong `JWT_SECRET` in `.env`. Kept across runs so existing tokens stay valid; `--rotate-secret` rolls it.
  - Configures admin auth: either `--admin-password` (argon2 hash → `ADMIN_PASSWORD_HASH`) or `--test-mode` (explicit, with `FUNKYGIBBON_TEST_PASSWORD`).
  - Mints a long-lived admin token and writes it into the **oook** (`~/.oook/config.json`) and **blowing-off** (`./.blowingoff.json`) configs.
  - Idempotent, `--dry-run`, comment-preserving `.env` upsert.
- **`funkygibbon/env_loader.py` (new) + `__init__.py`** — load `.env` into `os.environ` at package import (before the auth router reads `os.getenv`), real env vars winning. No new dependency. This is what makes setup-auth's `JWT_SECRET`/mode actually reach the server.
- **`config.py`** — `Settings(extra="ignore")` so the auth keys in `.env` don't trip pydantic-settings.
- **`oook/oook/cli.py`** — sends `Authorization: Bearer <token>`; token + URL resolve `flag > env > ~/.oook/config.json > default`, so setup-auth wires it with no per-command flags.
- **blowing-off** — no code change needed; it already threads the token through `InbetweeniesProtocol` headers end-to-end. setup-auth just writes its config.

## Tests

`tests/test_setup_auth.py`: `.env` upsert, idempotency, secret/token rotation, minted-token-verifies, dry-run writes nothing. **Full funkygibbon suite: 132 passed.**

Verified end-to-end against a real server loading the written `.env`: no token → 401/403, minted client token → 200, forged → 401; admin-password mode logs in and the old `"admin"` backdoor stays rejected.

## After this merges

Steps 1b is complete. `scripts/upgrade.sh` + `UPGRADE.md` (separate task) will sequence: stop service → backup → pull to tag → data-migrate (1c) → `setup-auth` → restart → verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)