### PR TITLE
feat(backup): backup/restore + scheduler, grafted onto hardened main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,6 @@ hive-mind-prompt-*.txt
 # Model files (large binary files)
 chat/models/
 *.gguf
+
+# Database backups created by the backup service
+backups/

--- a/funkygibbon/api/app.py
+++ b/funkygibbon/api/app.py
@@ -71,10 +71,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from ..config import settings
 from ..database import init_db
-from .routers import sync_metadata, graph, mcp, auth
+from .routers import sync_metadata, graph, mcp, auth, backup
 from .routers.auth import require_auth
 from . import sync as enhanced_sync
 from ..auth import auth_rate_limiter, audit_logger
+from ..backup_scheduler import init_scheduler, shutdown_scheduler
 
 
 @asynccontextmanager
@@ -92,10 +93,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
     await audit_logger.start_pattern_detection()
     print("Audit logger started")
 
+    # Start backup scheduler
+    scheduler = init_scheduler()
+    scheduler.start()
+    print("Backup scheduler started")
+
     yield
 
     # Shutdown
     print("Shutting down")
+
+    # Stop backup scheduler
+    shutdown_scheduler()
+    print("Backup scheduler stopped")
 
     # Stop background tasks
     await auth_rate_limiter.stop_cleanup_task()
@@ -123,6 +133,8 @@ def create_app() -> FastAPI:
 
     # Auth router stays public (login / guest verify handle their own checks).
     app.include_router(auth.router, prefix=f"{settings.api_prefix}", tags=["authentication"])
+    # Backup router guards each endpoint with an admin-token dependency of its own.
+    app.include_router(backup.router, prefix=f"{settings.api_prefix}", tags=["backup"])
 
     # All data routers require a valid bearer token. Applied at include time so
     # every current and future endpoint on these routers is protected by default

--- a/funkygibbon/api/routers/backup.py
+++ b/funkygibbon/api/routers/backup.py
@@ -1,0 +1,334 @@
+"""
+Backup and Restore API endpoints.
+
+Provides endpoints for creating, listing, and restoring database backups.
+All endpoints require admin authentication. Also includes endpoints for
+managing the automated backup scheduler.
+"""
+
+from fastapi import APIRouter, HTTPException, Depends, status
+from pydantic import BaseModel, Field
+from typing import List, Optional, Dict, Any
+
+from ...backup import BackupService
+from ...backup_scheduler import get_scheduler
+from .auth import require_admin
+
+
+# Initialize router
+router = APIRouter(prefix="/backup", tags=["backup"])
+
+# Initialize backup service
+backup_service = BackupService()
+
+
+# Request/Response models
+class CreateBackupRequest(BaseModel):
+    """Request to create a new backup."""
+    description: Optional[str] = Field(None, description="Optional description for the backup")
+
+
+class BackupInfo(BaseModel):
+    """Backup metadata information."""
+    backup_id: str
+    created_at: str
+    description: str
+    size_bytes: int
+    checksum: str
+    integrity_ok: bool
+    error: Optional[str] = None
+
+
+class CreateBackupResponse(BaseModel):
+    """Response after creating a backup."""
+    backup_id: str
+    message: str
+    size_bytes: int
+
+
+class RestoreBackupRequest(BaseModel):
+    """Request to restore from a backup."""
+    verify_checksum: bool = Field(True, description="Whether to verify backup integrity before restore")
+
+
+class RestoreBackupResponse(BaseModel):
+    """Response after restoring a backup."""
+    message: str
+    backup_id: str
+    warning: Optional[str] = None
+
+
+class SchedulerStatusResponse(BaseModel):
+    """Backup scheduler status information."""
+    enabled: bool
+    running: bool
+    interval_hours: int
+    retention_days: int
+    max_count: int
+    next_backup: Optional[str] = None
+    next_cleanup: Optional[str] = None
+
+
+class TriggerBackupResponse(BaseModel):
+    """Response after manually triggering a backup."""
+    backup_id: str
+    message: str
+
+
+@router.post("/create", response_model=CreateBackupResponse, status_code=status.HTTP_201_CREATED)
+async def create_backup(
+    request: CreateBackupRequest,
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Create a full database backup including all BLOBs.
+
+    This endpoint creates a complete backup of the FunkyGibbon database,
+    including all binary data (images, PDFs, etc.) stored in BLOB fields.
+
+    **Authentication:** Requires admin token
+
+    **Returns:**
+    - backup_id: Unique identifier for the backup
+    - message: Success message
+    - size_bytes: Size of the backup file
+    """
+    try:
+        backup_id = await backup_service.create_backup(description=request.description)
+
+        # Get backup info to return size
+        backup_info = await backup_service.get_backup_info(backup_id)
+
+        return CreateBackupResponse(
+            backup_id=backup_id,
+            message="Backup created successfully",
+            size_bytes=backup_info["size_bytes"]
+        )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create backup: {str(e)}"
+        )
+
+
+@router.get("/list", response_model=List[BackupInfo])
+async def list_backups(
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    List all available backups.
+
+    Returns a list of all backups with their metadata, including size,
+    creation time, and integrity status.
+
+    **Authentication:** Requires admin token
+
+    **Returns:**
+    List of backup metadata objects
+    """
+    try:
+        backups = await backup_service.list_backups()
+        return [BackupInfo(**backup) for backup in backups]
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list backups: {str(e)}"
+        )
+
+
+@router.get("/{backup_id}", response_model=BackupInfo)
+async def get_backup_info(
+    backup_id: str,
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Get detailed information about a specific backup.
+
+    Returns metadata for the specified backup including size, checksum,
+    and integrity validation status.
+
+    **Authentication:** Requires admin token
+
+    **Parameters:**
+    - backup_id: The unique identifier of the backup
+
+    **Returns:**
+    Backup metadata object
+    """
+    try:
+        backup_info = await backup_service.get_backup_info(backup_id)
+
+        if backup_info is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Backup {backup_id} not found"
+            )
+
+        return BackupInfo(**backup_info)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get backup info: {str(e)}"
+        )
+
+
+@router.post("/{backup_id}/restore", response_model=RestoreBackupResponse)
+async def restore_backup(
+    backup_id: str,
+    request: RestoreBackupRequest,
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Restore the database from a backup.
+
+    **⚠️ WARNING:** This operation will replace the current database with
+    the backup. The server should be restarted after restoration to ensure
+    all connections are properly reset.
+
+    **Authentication:** Requires admin token
+
+    **Parameters:**
+    - backup_id: The unique identifier of the backup to restore
+    - verify_checksum: Whether to verify backup integrity (default: true)
+
+    **Returns:**
+    Success message with restoration details
+    """
+    try:
+        await backup_service.restore_backup(
+            backup_id=backup_id,
+            verify_checksum=request.verify_checksum
+        )
+
+        return RestoreBackupResponse(
+            message="Database restored successfully from backup",
+            backup_id=backup_id,
+            warning="Server restart recommended to ensure proper operation"
+        )
+
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to restore backup: {str(e)}"
+        )
+
+
+@router.delete("/{backup_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_backup(
+    backup_id: str,
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Delete a backup and its metadata.
+
+    **Authentication:** Requires admin token
+
+    **Parameters:**
+    - backup_id: The unique identifier of the backup to delete
+    """
+    try:
+        await backup_service.delete_backup(backup_id)
+        return None  # 204 No Content response
+
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to delete backup: {str(e)}"
+        )
+
+
+# Scheduler Management Endpoints
+
+@router.get("/scheduler/status", response_model=SchedulerStatusResponse)
+async def get_scheduler_status(
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Get the current status of the backup scheduler.
+
+    Returns information about scheduler configuration, running state,
+    and next scheduled backup times.
+
+    **Authentication:** Requires admin token
+
+    **Returns:**
+    Scheduler status and configuration
+    """
+    try:
+        scheduler = get_scheduler()
+        status_info = scheduler.get_status()
+        return SchedulerStatusResponse(**status_info)
+
+    except RuntimeError as e:
+        # Scheduler not initialized
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(e)
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get scheduler status: {str(e)}"
+        )
+
+
+@router.post("/scheduler/trigger", response_model=TriggerBackupResponse, status_code=status.HTTP_201_CREATED)
+async def trigger_backup_now(
+    token_data: Dict = Depends(require_admin)
+):
+    """
+    Manually trigger a backup immediately.
+
+    Creates a backup outside of the normal schedule. Useful for
+    creating a backup before risky operations.
+
+    **Authentication:** Requires admin token
+
+    **Returns:**
+    Information about the created backup
+    """
+    try:
+        scheduler = get_scheduler()
+        backup_id = scheduler.trigger_backup_now()
+
+        return TriggerBackupResponse(
+            backup_id=backup_id,
+            message="Backup triggered successfully"
+        )
+
+    except RuntimeError as e:
+        # Scheduler not initialized - fall back to direct backup service
+        try:
+            backup_id = await backup_service.create_backup(
+                description="Manually triggered backup"
+            )
+            return TriggerBackupResponse(
+                backup_id=backup_id,
+                message="Backup created successfully (scheduler not available)"
+            )
+        except Exception as backup_error:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Failed to create backup: {str(backup_error)}"
+            )
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to trigger backup: {str(e)}"
+        )

--- a/funkygibbon/backup.py
+++ b/funkygibbon/backup.py
@@ -1,0 +1,345 @@
+"""
+FunkyGibbon - Backup and Restore Service
+
+DEVELOPMENT CONTEXT:
+Created to provide comprehensive backup and restore functionality for the
+FunkyGibbon server, ensuring all data including BLOBs (images, PDFs) stored
+in SQLite are properly backed up and can be reliably restored.
+
+FUNCTIONALITY:
+- Creates full database backups with metadata tracking
+- Validates backup integrity using SHA-256 checksums
+- Lists available backups with size and timestamp information
+- Restores database from backup with validation
+- Manages backup lifecycle (creation, deletion, cleanup)
+- Includes BLOB data in backups automatically via SQLite export
+
+PURPOSE:
+Ensures data safety and disaster recovery capabilities for FunkyGibbon
+deployments, with special attention to preserving binary data (BLOBs)
+that are stored within the SQLite database.
+
+DESIGN DECISIONS:
+- Uses SQLite VACUUM INTO for atomic backup creation
+- Stores backups in ./backups/ directory by default
+- Backup metadata stored in JSON alongside each backup file
+- Checksums validate data integrity before restore
+- Restore requires server restart to prevent database corruption
+
+KNOWN LIMITATIONS:
+- Backups are local only (no cloud storage integration)
+- Restore requires stopping/restarting the server
+- No incremental backup support (always full backups)
+- No compression (raw SQLite files)
+
+REVISION HISTORY:
+- 2026-04-07: Initial implementation with full backup/restore support
+
+DEPENDENCIES:
+- pathlib: Path handling for backup files
+- hashlib: SHA-256 checksums for integrity validation
+- json: Metadata serialization
+- shutil: File copy operations for restore
+- sqlalchemy: Database connection management
+
+USAGE:
+```python
+# Create a backup
+backup_service = BackupService()
+backup_id = await backup_service.create_backup()
+
+# List backups
+backups = await backup_service.list_backups()
+
+# Restore from backup
+await backup_service.restore_backup(backup_id)
+```
+"""
+
+import hashlib
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .database import engine, get_db_context
+from .config import settings
+
+
+class BackupService:
+    """
+    Service for creating and managing database backups.
+
+    This service handles full SQLite database backups including all BLOBs
+    stored in the database. Backups are stored locally with metadata and
+    integrity checksums.
+    """
+
+    def __init__(self, backup_dir: Optional[Path] = None, db_path: Optional[Path] = None):
+        """
+        Initialize backup service.
+
+        Args:
+            backup_dir: Directory to store backups (defaults to ./backups)
+            db_path: Path to database file (defaults to parsing from settings.database_url)
+        """
+        self.backup_dir = backup_dir or Path("./backups")
+        self.backup_dir.mkdir(exist_ok=True, parents=True)
+
+        # Extract database file path from connection string or use provided path
+        if db_path:
+            self.db_path = db_path
+        else:
+            # Format: sqlite+aiosqlite:///./funkygibbon.db
+            db_url = settings.database_url
+            if ":///" in db_url:
+                db_file = db_url.split("///")[1]
+                self.db_path = Path(db_file) if db_file else Path("./funkygibbon.db")
+            else:
+                # Default fallback
+                self.db_path = Path("./funkygibbon.db")
+
+    async def create_backup(self, description: Optional[str] = None) -> str:
+        """
+        Create a full database backup including all BLOBs.
+
+        Uses SQLite VACUUM INTO for atomic backup creation. This ensures
+        all data including BLOBs stored in LargeBinary columns are included.
+
+        Args:
+            description: Optional description for the backup
+
+        Returns:
+            Backup ID (timestamp-based identifier)
+
+        Raises:
+            RuntimeError: If backup creation fails
+        """
+        # Generate backup ID from timestamp
+        backup_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        backup_file = self.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+
+        try:
+            # Use VACUUM INTO for atomic backup (SQLite 3.27.0+)
+            # This creates a complete copy including all BLOBs
+            async with get_db_context() as session:
+                await session.execute(text(f"VACUUM INTO '{backup_file}'"))
+                await session.commit()
+
+            # Calculate checksum for integrity validation
+            checksum = self._calculate_file_checksum(backup_file)
+
+            # Create metadata file
+            metadata = {
+                "backup_id": backup_id,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "description": description or "Full database backup",
+                "database_path": str(self.db_path),
+                "backup_file": str(backup_file.name),
+                "size_bytes": backup_file.stat().st_size,
+                "checksum": checksum,
+                "version": "1.0"
+            }
+
+            metadata_file = self.backup_dir / f"funkygibbon_backup_{backup_id}.json"
+            with open(metadata_file, 'w') as f:
+                json.dump(metadata, f, indent=2)
+
+            return backup_id
+
+        except Exception as e:
+            # Clean up partial backup if it exists
+            if backup_file.exists():
+                backup_file.unlink()
+            raise RuntimeError(f"Backup creation failed: {str(e)}")
+
+    async def list_backups(self) -> List[Dict[str, Any]]:
+        """
+        List all available backups with metadata.
+
+        Returns:
+            List of backup metadata dictionaries
+        """
+        backups = []
+
+        for metadata_file in sorted(self.backup_dir.glob("*.json"), reverse=True):
+            try:
+                with open(metadata_file, 'r') as f:
+                    metadata = json.load(f)
+
+                # Verify backup file still exists
+                backup_file = self.backup_dir / metadata["backup_file"]
+                if backup_file.exists():
+                    # Add current file size (may differ if corruption occurred)
+                    metadata["current_size_bytes"] = backup_file.stat().st_size
+                    metadata["integrity_ok"] = (
+                        metadata["current_size_bytes"] == metadata["size_bytes"]
+                    )
+                    backups.append(metadata)
+                else:
+                    metadata["integrity_ok"] = False
+                    metadata["error"] = "Backup file missing"
+                    backups.append(metadata)
+
+            except Exception as e:
+                # Include corrupted metadata in listing with error
+                backups.append({
+                    "backup_id": metadata_file.stem.replace("funkygibbon_backup_", ""),
+                    "error": f"Failed to read metadata: {str(e)}",
+                    "integrity_ok": False
+                })
+
+        return backups
+
+    async def get_backup_info(self, backup_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get metadata for a specific backup.
+
+        Args:
+            backup_id: Backup identifier
+
+        Returns:
+            Backup metadata dictionary or None if not found
+        """
+        metadata_file = self.backup_dir / f"funkygibbon_backup_{backup_id}.json"
+
+        if not metadata_file.exists():
+            return None
+
+        try:
+            with open(metadata_file, 'r') as f:
+                metadata = json.load(f)
+
+            # Verify backup file exists and validate checksum
+            backup_file = self.backup_dir / metadata["backup_file"]
+            if backup_file.exists():
+                current_checksum = self._calculate_file_checksum(backup_file)
+                metadata["current_checksum"] = current_checksum
+                metadata["integrity_ok"] = (current_checksum == metadata["checksum"])
+            else:
+                metadata["integrity_ok"] = False
+                metadata["error"] = "Backup file missing"
+
+            return metadata
+
+        except Exception as e:
+            return {
+                "backup_id": backup_id,
+                "error": f"Failed to read metadata: {str(e)}",
+                "integrity_ok": False
+            }
+
+    async def restore_backup(self, backup_id: str, verify_checksum: bool = True) -> None:
+        """
+        Restore database from backup.
+
+        WARNING: This operation requires the server to be stopped before
+        restoration and restarted after. The database file will be replaced.
+
+        Args:
+            backup_id: Backup identifier to restore from
+            verify_checksum: Whether to verify backup integrity before restore
+
+        Raises:
+            ValueError: If backup not found or integrity check fails
+            RuntimeError: If restore operation fails
+        """
+        metadata = await self.get_backup_info(backup_id)
+
+        if metadata is None:
+            raise ValueError(f"Backup {backup_id} not found")
+
+        if "error" in metadata:
+            raise ValueError(f"Cannot restore: {metadata['error']}")
+
+        backup_file = self.backup_dir / metadata["backup_file"]
+
+        # Verify integrity if requested
+        if verify_checksum:
+            if not metadata.get("integrity_ok", False):
+                raise ValueError("Backup integrity check failed - checksum mismatch")
+
+        try:
+            # Create a safety backup of current database before restore
+            safety_backup = self.db_path.parent / f"{self.db_path.name}.pre_restore"
+            if self.db_path.exists():
+                shutil.copy2(self.db_path, safety_backup)
+
+            # Restore by copying backup over current database
+            # NOTE: This requires no active connections to the database
+            shutil.copy2(backup_file, self.db_path)
+
+            # Remove the WAL/SHM sidecars. In WAL mode a leftover write-ahead log
+            # from the live database would be replayed on top of the restored
+            # file, resurrecting changes made after the backup was taken.
+            for suffix in ("-wal", "-shm"):
+                sidecar = self.db_path.parent / f"{self.db_path.name}{suffix}"
+                if sidecar.exists():
+                    sidecar.unlink()
+
+            # Clean up safety backup on success
+            if safety_backup.exists():
+                safety_backup.unlink()
+
+        except Exception as e:
+            # Attempt to restore from safety backup if restore failed
+            if safety_backup.exists():
+                try:
+                    shutil.copy2(safety_backup, self.db_path)
+                except:
+                    pass  # Can't do much if safety restore fails
+
+            raise RuntimeError(f"Restore failed: {str(e)}")
+
+    async def delete_backup(self, backup_id: str) -> None:
+        """
+        Delete a backup and its metadata.
+
+        Args:
+            backup_id: Backup identifier to delete
+
+        Raises:
+            ValueError: If backup not found
+        """
+        metadata_file = self.backup_dir / f"funkygibbon_backup_{backup_id}.json"
+        backup_file = self.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+
+        if not metadata_file.exists():
+            raise ValueError(f"Backup {backup_id} not found")
+
+        # Read metadata to get exact backup filename
+        try:
+            with open(metadata_file, 'r') as f:
+                metadata = json.load(f)
+            backup_file = self.backup_dir / metadata["backup_file"]
+        except:
+            pass  # Use default filename if metadata can't be read
+
+        # Delete files
+        if backup_file.exists():
+            backup_file.unlink()
+        if metadata_file.exists():
+            metadata_file.unlink()
+
+    def _calculate_file_checksum(self, file_path: Path) -> str:
+        """
+        Calculate SHA-256 checksum of a file.
+
+        Args:
+            file_path: Path to file
+
+        Returns:
+            Hexadecimal checksum string
+        """
+        sha256_hash = hashlib.sha256()
+
+        with open(file_path, "rb") as f:
+            # Read in chunks to handle large files
+            for byte_block in iter(lambda: f.read(4096), b""):
+                sha256_hash.update(byte_block)
+
+        return sha256_hash.hexdigest()

--- a/funkygibbon/backup_scheduler.py
+++ b/funkygibbon/backup_scheduler.py
@@ -1,0 +1,402 @@
+"""
+FunkyGibbon - Scheduled Backup Manager
+
+DEVELOPMENT CONTEXT:
+Created to provide automated, scheduled backup functionality for the
+FunkyGibbon server. Ensures regular backups are created automatically
+and old backups are cleaned up according to retention policies.
+
+FUNCTIONALITY:
+- Schedules periodic backups using APScheduler
+- Automatically creates backups at configured intervals
+- Manages backup retention (removes old backups)
+- Provides start/stop control for the scheduler
+- Supports configuration via settings
+- Thread-safe scheduler management
+
+PURPOSE:
+Automated backup protection for FunkyGibbon deployments. Removes the
+need for manual backup creation and ensures data safety through
+regular, automatic backups with retention management.
+
+DESIGN DECISIONS:
+- Uses APScheduler for reliable task scheduling
+- Background thread executor for non-blocking operation
+- Configurable schedule interval and retention policy
+- Graceful start/stop for application lifecycle integration
+- Automatic cleanup of old backups based on age and count
+
+KNOWN LIMITATIONS:
+- Only supports local backups (no cloud storage)
+- Scheduler runs in-process (requires server to be running)
+- No notification system for backup failures
+- Fixed interval scheduling (no cron-style expressions)
+
+REVISION HISTORY:
+- 2026-04-07: Initial implementation with interval-based scheduling
+
+DEPENDENCIES:
+- apscheduler: Task scheduling framework
+- .backup: BackupService for creating backups
+- .config: Configuration settings
+
+USAGE:
+```python
+# Create and start scheduler
+scheduler = BackupScheduler()
+scheduler.start()
+
+# Later, when shutting down
+scheduler.stop()
+```
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from .backup import BackupService
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class BackupScheduler:
+    """
+    Manages scheduled automatic backups for FunkyGibbon.
+
+    Uses APScheduler to create backups at regular intervals and
+    automatically clean up old backups based on retention policies.
+    """
+
+    def __init__(
+        self,
+        backup_service: Optional[BackupService] = None,
+        enabled: Optional[bool] = None,
+        interval_hours: Optional[int] = None,
+        retention_days: Optional[int] = None,
+        max_count: Optional[int] = None
+    ):
+        """
+        Initialize the backup scheduler.
+
+        Args:
+            backup_service: BackupService instance (creates one if not provided)
+            enabled: Whether scheduler is enabled (defaults to config)
+            interval_hours: Hours between backups (defaults to config)
+            retention_days: Days to keep backups (defaults to config)
+            max_count: Maximum number of backups to keep (defaults to config)
+        """
+        self.backup_service = backup_service or BackupService()
+
+        # Load configuration
+        self.enabled = enabled if enabled is not None else settings.backup_schedule_enabled
+        self.interval_hours = interval_hours or settings.backup_schedule_interval_hours
+        self.retention_days = retention_days or settings.backup_retention_days
+        self.max_count = max_count or settings.backup_max_count
+
+        # Create scheduler
+        self.scheduler = BackgroundScheduler()
+        self._is_running = False
+
+        logger.info(
+            f"Backup scheduler initialized: enabled={self.enabled}, "
+            f"interval={self.interval_hours}h, retention={self.retention_days}d, "
+            f"max_count={self.max_count}"
+        )
+
+    def start(self) -> None:
+        """
+        Start the backup scheduler.
+
+        Schedules periodic backups and cleanup tasks based on configuration.
+        Does nothing if scheduler is disabled or already running.
+        """
+        if not self.enabled:
+            logger.info("Backup scheduler is disabled in configuration")
+            return
+
+        if self._is_running:
+            logger.warning("Backup scheduler is already running")
+            return
+
+        # Schedule backup job
+        self.scheduler.add_job(
+            func=self._run_backup,
+            trigger=IntervalTrigger(hours=self.interval_hours),
+            id="scheduled_backup",
+            name="Scheduled Database Backup",
+            replace_existing=True
+        )
+
+        # Schedule cleanup job (runs daily)
+        self.scheduler.add_job(
+            func=self._run_cleanup,
+            trigger=IntervalTrigger(hours=24),
+            id="backup_cleanup",
+            name="Backup Retention Cleanup",
+            replace_existing=True
+        )
+
+        self.scheduler.start()
+        self._is_running = True
+
+        logger.info(
+            f"Backup scheduler started - backups every {self.interval_hours} hours"
+        )
+
+        # Run initial backup immediately
+        self._run_backup()
+
+    def stop(self) -> None:
+        """
+        Stop the backup scheduler.
+
+        Gracefully shuts down the scheduler and waits for any
+        in-progress jobs to complete.
+        """
+        if not self._is_running:
+            logger.info("Backup scheduler is not running")
+            return
+
+        logger.info("Stopping backup scheduler...")
+        self.scheduler.shutdown(wait=True)
+        self._is_running = False
+        logger.info("Backup scheduler stopped")
+
+    def is_running(self) -> bool:
+        """Check if the scheduler is currently running."""
+        return self._is_running
+
+    def get_status(self) -> dict:
+        """
+        Get current scheduler status and configuration.
+
+        Returns:
+            Dictionary with scheduler status information
+        """
+        return {
+            "enabled": self.enabled,
+            "running": self._is_running,
+            "interval_hours": self.interval_hours,
+            "retention_days": self.retention_days,
+            "max_count": self.max_count,
+            "next_backup": self._get_next_run_time("scheduled_backup"),
+            "next_cleanup": self._get_next_run_time("backup_cleanup")
+        }
+
+    def trigger_backup_now(self) -> str:
+        """
+        Manually trigger a backup immediately.
+
+        Returns:
+            Backup ID of the created backup
+
+        Raises:
+            RuntimeError: If backup creation fails
+        """
+        logger.info("Manual backup triggered")
+        return self._run_backup()
+
+    def _get_next_run_time(self, job_id: str) -> Optional[str]:
+        """Get the next scheduled run time for a job."""
+        if not self._is_running:
+            return None
+
+        job = self.scheduler.get_job(job_id)
+        if job and job.next_run_time:
+            return job.next_run_time.isoformat()
+        return None
+
+    def _run_backup(self) -> str:
+        """
+        Execute a backup operation.
+
+        This is the main backup job that runs on schedule.
+        Creates a backup with automatic description.
+
+        Returns:
+            Backup ID of the created backup
+        """
+        try:
+            # Check if we're already in an async context
+            try:
+                loop = asyncio.get_running_loop()
+                # We're in an async context, use current loop
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(self._run_backup_sync)
+                    backup_id = future.result()
+                return backup_id
+            except RuntimeError:
+                # No running loop, create a new one
+                return self._run_backup_sync()
+
+        except Exception as e:
+            logger.error(f"Scheduled backup failed: {str(e)}", exc_info=True)
+            raise
+
+    def _run_backup_sync(self) -> str:
+        """
+        Execute backup in a new event loop.
+
+        Helper method that always creates a new event loop for the backup.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        description = f"Scheduled backup - {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}"
+        backup_id = loop.run_until_complete(
+            self.backup_service.create_backup(description=description)
+        )
+
+        loop.close()
+
+        logger.info(f"Scheduled backup created successfully: {backup_id}")
+        return backup_id
+
+    def _run_cleanup(self) -> dict:
+        """
+        Execute backup cleanup based on retention policies.
+
+        Removes backups that are:
+        1. Older than retention_days
+        2. Beyond max_count (keeps most recent)
+
+        Returns:
+            Dictionary with cleanup statistics
+        """
+        try:
+            # Check if we're already in an async context
+            try:
+                _ = asyncio.get_running_loop()
+                # We're in an async context, use thread pool
+                import concurrent.futures
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(self._run_cleanup_sync)
+                    return future.result()
+            except RuntimeError:
+                # No running loop, create a new one
+                return self._run_cleanup_sync()
+
+        except Exception as e:
+            logger.error(f"Backup cleanup failed: {str(e)}", exc_info=True)
+            raise
+
+    def _run_cleanup_sync(self) -> dict:
+        """
+        Execute cleanup in a new event loop.
+
+        Helper method that always creates a new event loop for cleanup.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        # Get all backups
+        backups = loop.run_until_complete(self.backup_service.list_backups())
+
+        deleted_count = 0
+        cutoff_date = datetime.now(timezone.utc) - timedelta(days=self.retention_days)
+
+        # Sort by creation date (newest first)
+        backups_sorted = sorted(
+            backups,
+            key=lambda b: b.get("created_at", ""),
+            reverse=True
+        )
+
+        for i, backup in enumerate(backups_sorted):
+            backup_id = backup["backup_id"]
+            should_delete = False
+            reason = ""
+
+            # Check age-based retention
+            try:
+                created_at = datetime.fromisoformat(backup["created_at"].replace('Z', '+00:00'))
+                if created_at < cutoff_date:
+                    should_delete = True
+                    reason = f"older than {self.retention_days} days"
+            except (ValueError, KeyError):
+                pass
+
+            # Check count-based retention
+            if i >= self.max_count:
+                should_delete = True
+                reason = f"beyond max count ({self.max_count})"
+
+            # Delete if needed
+            if should_delete:
+                try:
+                    loop.run_until_complete(
+                        self.backup_service.delete_backup(backup_id)
+                    )
+                    deleted_count += 1
+                    logger.info(f"Deleted backup {backup_id} - {reason}")
+                except Exception as e:
+                    logger.error(f"Failed to delete backup {backup_id}: {str(e)}")
+
+        loop.close()
+
+        result = {
+            "deleted_count": deleted_count,
+            "remaining_count": len(backups) - deleted_count,
+            "retention_days": self.retention_days,
+            "max_count": self.max_count
+        }
+
+        logger.info(
+            f"Backup cleanup completed: deleted {deleted_count}, "
+            f"remaining {result['remaining_count']}"
+        )
+
+        return result
+
+
+# Global scheduler instance (initialized in app lifespan)
+_scheduler_instance: Optional[BackupScheduler] = None
+
+
+def get_scheduler() -> BackupScheduler:
+    """
+    Get the global scheduler instance.
+
+    Returns:
+        Global BackupScheduler instance
+
+    Raises:
+        RuntimeError: If scheduler hasn't been initialized
+    """
+    if _scheduler_instance is None:
+        raise RuntimeError("Backup scheduler not initialized")
+    return _scheduler_instance
+
+
+def init_scheduler() -> BackupScheduler:
+    """
+    Initialize the global scheduler instance.
+
+    Should be called during application startup.
+
+    Returns:
+        Initialized BackupScheduler instance
+    """
+    global _scheduler_instance
+    _scheduler_instance = BackupScheduler()
+    return _scheduler_instance
+
+
+def shutdown_scheduler() -> None:
+    """
+    Shutdown the global scheduler instance.
+
+    Should be called during application shutdown.
+    """
+    global _scheduler_instance
+    if _scheduler_instance is not None:
+        _scheduler_instance.stop()
+        _scheduler_instance = None

--- a/funkygibbon/config.py
+++ b/funkygibbon/config.py
@@ -90,6 +90,12 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = Field(default="INFO", validation_alias="LOG_LEVEL")
 
+    # Backup Scheduler
+    backup_schedule_enabled: bool = Field(default=True, validation_alias="BACKUP_SCHEDULE_ENABLED")
+    backup_schedule_interval_hours: int = Field(default=24, validation_alias="BACKUP_SCHEDULE_INTERVAL_HOURS")
+    backup_retention_days: int = Field(default=30, validation_alias="BACKUP_RETENTION_DAYS")
+    backup_max_count: int = Field(default=10, validation_alias="BACKUP_MAX_COUNT")
+
 
 # Global settings instance
 settings = Settings()

--- a/funkygibbon/requirements.txt
+++ b/funkygibbon/requirements.txt
@@ -15,3 +15,4 @@ argon2-cffi>=25.1.0
 pyjwt>=2.8.0
 qrcode>=8.2
 pillow>=12.2.0
+apscheduler>=3.10.4

--- a/funkygibbon/tests/test_backup.py
+++ b/funkygibbon/tests/test_backup.py
@@ -1,0 +1,419 @@
+"""
+Tests for backup and restore functionality.
+
+Covers the BackupService class, the BackupScheduler, and the backup API
+endpoints — backups (including BLOBs) are created and restored correctly.
+
+These tests are deliberately synchronous. The backup code is async, so it is
+driven via `arun()` (a thin asyncio.run wrapper that disposes the shared engine
+around each call). Every test runs chdir'd into its own tmp dir, so the relative
+database (`./funkygibbon.db`) and `./backups` land in isolation and never touch
+the repo.
+"""
+
+import asyncio
+import json
+import sqlite3
+import time
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import NullPool
+from fastapi.testclient import TestClient
+
+import funkygibbon.database as dbmod
+from funkygibbon.backup import BackupService
+from funkygibbon.backup_scheduler import BackupScheduler
+from funkygibbon.database import get_db_context, init_db
+from funkygibbon.config import settings
+from funkygibbon.api.app import create_app
+
+SAMPLE_BLOB = b"This is test binary data for backup testing"
+
+
+def arun(coro):
+    """Run a coroutine to completion. Each test owns an isolated NullPool engine
+    (see _isolated_db), so connections close eagerly and never leak across loops."""
+    return asyncio.run(coro)
+
+
+async def _seed_sample_db():
+    await init_db()
+    async with get_db_context() as session:
+        await session.execute(text(
+            "CREATE TABLE IF NOT EXISTS test_data "
+            "(id INTEGER PRIMARY KEY, name TEXT, data BLOB)"
+        ))
+        await session.execute(text("DELETE FROM test_data"))
+        await session.execute(
+            text("INSERT INTO test_data (id, name, data) VALUES (:id, :name, :data)"),
+            {"id": 1, "name": "test_record", "data": SAMPLE_BLOB},
+        )
+        await session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    """Give each test its own database on an absolute path with a NullPool engine.
+
+    The shared module engine uses a *relative* path with connection pooling, so
+    a pooled connection from one test bleeds into the next regardless of cwd.
+    Patching a per-test NullPool engine (connections close eagerly, WAL is
+    checkpointed on close) makes backup/restore deterministic. chdir keeps the
+    backup router's default ./backups dir inside the tmp dir too.
+    """
+    db_file = tmp_path / "funkygibbon.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    test_engine = create_async_engine(url, connect_args={"timeout": 5}, poolclass=NullPool)
+    test_sessionmaker = async_sessionmaker(test_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(dbmod, "engine", test_engine)
+    monkeypatch.setattr(dbmod, "async_session", test_sessionmaker)
+    monkeypatch.setattr(settings, "database_url", url)
+    monkeypatch.chdir(tmp_path)
+    yield db_file
+    asyncio.run(test_engine.dispose())
+
+
+@pytest.fixture
+def backup_dir(tmp_path):
+    d = tmp_path / "test_backups"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def backup_service(backup_dir):
+    return BackupService(backup_dir=backup_dir)
+
+
+@pytest.fixture
+def sample_database():
+    """Seed the (chdir'd, isolated) database with a row including a BLOB."""
+    arun(_seed_sample_db())
+    yield
+
+
+class TestBackupService:
+    """Tests for the BackupService class."""
+
+    def test_create_backup(self, backup_service, sample_database):
+        backup_id = arun(backup_service.create_backup(description="Test backup"))
+
+        assert len(backup_id) == 15  # YYYYMMDD_HHMMSS
+        assert "_" in backup_id
+
+        backup_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+        assert backup_file.exists()
+        assert backup_file.stat().st_size > 0
+
+        metadata_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.json"
+        assert metadata_file.exists()
+        metadata = json.loads(metadata_file.read_text())
+        assert metadata["backup_id"] == backup_id
+        assert metadata["description"] == "Test backup"
+        assert "checksum" in metadata
+        assert metadata["size_bytes"] > 0
+
+    def test_backup_includes_blob_data(self, backup_service, sample_database):
+        backup_id = arun(backup_service.create_backup())
+        backup_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+
+        # Read the backup file directly (stdlib sqlite3, synchronous).
+        conn = sqlite3.connect(backup_file)
+        try:
+            row = conn.execute("SELECT data FROM test_data WHERE id = 1").fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == SAMPLE_BLOB
+
+    def test_list_backups(self, backup_service, sample_database):
+        async def _flow():
+            id1 = await backup_service.create_backup(description="Backup 1")
+            await asyncio.sleep(1.1)  # backup ids are second-resolution
+            id2 = await backup_service.create_backup(description="Backup 2")
+            return id1, id2, await backup_service.list_backups()
+
+        id1, id2, backups = arun(_flow())
+        assert len(backups) >= 2
+        ids = [b["backup_id"] for b in backups]
+        assert id1 in ids and id2 in ids
+        for backup in backups:
+            assert "integrity_ok" in backup
+
+    def test_get_backup_info(self, backup_service, sample_database):
+        async def _flow():
+            backup_id = await backup_service.create_backup(description="Info test")
+            return backup_id, await backup_service.get_backup_info(backup_id)
+
+        backup_id, info = arun(_flow())
+        assert info is not None
+        assert info["backup_id"] == backup_id
+        assert info["description"] == "Info test"
+        assert info["integrity_ok"] is True
+        assert info["checksum"] == info["current_checksum"]
+
+    def test_get_nonexistent_backup_info(self, backup_service):
+        assert arun(backup_service.get_backup_info("nonexistent_backup")) is None
+
+    def test_restore_backup(self, backup_service, sample_database):
+        async def _flow():
+            backup_id = await backup_service.create_backup()
+
+            # Add a second record after the backup.
+            async with get_db_context() as session:
+                await session.execute(
+                    text("INSERT INTO test_data (id, name, data) VALUES (:id, :name, :data)"),
+                    {"id": 2, "name": "new_record", "data": b"new data"},
+                )
+                await session.commit()
+            async with get_db_context() as session:
+                count = (await session.execute(text("SELECT COUNT(*) FROM test_data"))).scalar()
+                assert count == 2
+
+            await backup_service.restore_backup(backup_id)
+
+            async with get_db_context() as session:
+                count = (await session.execute(text("SELECT COUNT(*) FROM test_data"))).scalar()
+                name = (await session.execute(text("SELECT name FROM test_data WHERE id = 1"))).scalar()
+            return count, name
+
+        count, name = arun(_flow())
+        assert count == 1
+        assert name == "test_record"
+
+    def test_restore_with_checksum_verification(self, backup_service, sample_database):
+        async def _flow():
+            backup_id = await backup_service.create_backup()
+            await backup_service.restore_backup(backup_id, verify_checksum=True)
+
+        arun(_flow())  # should not raise
+
+    def test_restore_corrupted_backup_fails(self, backup_service, sample_database):
+        backup_id = arun(backup_service.create_backup())
+
+        backup_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+        with open(backup_file, "ab") as f:
+            f.write(b"CORRUPTED DATA")
+
+        with pytest.raises(ValueError, match="integrity check failed"):
+            arun(backup_service.restore_backup(backup_id, verify_checksum=True))
+
+    def test_restore_nonexistent_backup_fails(self, backup_service):
+        with pytest.raises(ValueError, match="not found"):
+            arun(backup_service.restore_backup("nonexistent_backup"))
+
+    def test_delete_backup(self, backup_service, sample_database):
+        backup_id = arun(backup_service.create_backup())
+        backup_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.db"
+        metadata_file = backup_service.backup_dir / f"funkygibbon_backup_{backup_id}.json"
+        assert backup_file.exists() and metadata_file.exists()
+
+        arun(backup_service.delete_backup(backup_id))
+        assert not backup_file.exists()
+        assert not metadata_file.exists()
+
+    def test_delete_nonexistent_backup_fails(self, backup_service):
+        with pytest.raises(ValueError, match="not found"):
+            arun(backup_service.delete_backup("nonexistent_backup"))
+
+    def test_backup_checksum_calculation(self, backup_service, sample_database):
+        async def _flow():
+            backup_id = await backup_service.create_backup()
+            return await backup_service.get_backup_info(backup_id)
+
+        info = arun(_flow())
+        assert info["checksum"] == info["current_checksum"]
+        assert len(info["checksum"]) == 64  # SHA-256 hex
+
+
+class TestBackupScheduler:
+    """Tests for the BackupScheduler class."""
+
+    @pytest.fixture
+    def scheduler_backup_dir(self, tmp_path):
+        d = tmp_path / "scheduler_test_backups"
+        d.mkdir()
+        return d
+
+    @pytest.fixture
+    def scheduler(self, scheduler_backup_dir):
+        service = BackupService(backup_dir=scheduler_backup_dir)
+        sched = BackupScheduler(
+            backup_service=service,
+            enabled=True,
+            interval_hours=1,
+            retention_days=7,
+            max_count=5,
+        )
+        yield sched
+        if sched.is_running():
+            sched.stop()
+
+    def test_scheduler_initialization(self, scheduler):
+        assert scheduler.enabled is True
+        assert scheduler.interval_hours == 1
+        assert scheduler.retention_days == 7
+        assert scheduler.max_count == 5
+        assert scheduler.is_running() is False
+
+    def test_scheduler_start_stop(self, scheduler):
+        scheduler.start()
+        assert scheduler.is_running() is True
+        scheduler.stop()
+        assert scheduler.is_running() is False
+
+    def test_scheduler_status(self, scheduler):
+        status = scheduler.get_status()
+        for key in ("enabled", "running", "interval_hours", "retention_days", "max_count"):
+            assert key in status
+        assert status["enabled"] is True
+        assert status["interval_hours"] == 1
+
+    def test_manual_backup_trigger(self, scheduler, sample_database):
+        backup_id = scheduler.trigger_backup_now()
+        assert backup_id is not None
+        assert len(backup_id) == 15
+
+        info = arun(scheduler.backup_service.get_backup_info(backup_id))
+        assert info is not None
+        assert info["integrity_ok"] is True
+
+    def test_backup_cleanup_by_age(self, scheduler, sample_database):
+        old_backup_id = scheduler.trigger_backup_now()
+
+        # Backdate its metadata beyond the 7-day retention window.
+        metadata_file = scheduler.backup_service.backup_dir / f"funkygibbon_backup_{old_backup_id}.json"
+        metadata = json.loads(metadata_file.read_text())
+        metadata["created_at"] = (datetime.now(timezone.utc) - timedelta(days=8)).isoformat()
+        metadata_file.write_text(json.dumps(metadata, indent=2))
+
+        time.sleep(1.1)  # distinct second-resolution backup id
+        recent_backup_id = scheduler.trigger_backup_now()
+
+        result = scheduler._run_cleanup()
+
+        assert arun(scheduler.backup_service.get_backup_info(old_backup_id)) is None
+        assert arun(scheduler.backup_service.get_backup_info(recent_backup_id)) is not None
+        assert result["deleted_count"] >= 1
+
+    def test_backup_cleanup_by_count(self, scheduler, sample_database):
+        for i in range(7):  # max_count is 5
+            scheduler.trigger_backup_now()
+            time.sleep(1.0)  # ids are second-resolution; ensure distinct timestamps
+
+        result = scheduler._run_cleanup()
+        assert result["deleted_count"] == 2
+        assert result["remaining_count"] == 5
+
+        remaining = arun(scheduler.backup_service.list_backups())
+        assert len(remaining) == 5
+
+    def test_scheduler_disabled(self, scheduler_backup_dir):
+        service = BackupService(backup_dir=scheduler_backup_dir)
+        sched = BackupScheduler(backup_service=service, enabled=False)
+        sched.start()
+        assert sched.is_running() is False
+
+    def test_scheduler_idempotent_start(self, scheduler):
+        scheduler.start()
+        assert scheduler.is_running() is True
+        scheduler.start()  # safe to call again
+        assert scheduler.is_running() is True
+        scheduler.stop()
+
+    def test_scheduler_idempotent_stop(self, scheduler):
+        scheduler.stop()
+        assert scheduler.is_running() is False
+        scheduler.stop()  # safe to call again
+        assert scheduler.is_running() is False
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """Sync TestClient with the periodic backup scheduler disabled (manual
+    triggers still work). Lifespan creates the (isolated) DB and tables."""
+    monkeypatch.setattr(settings, "backup_schedule_enabled", False)
+    with TestClient(create_app()) as c:
+        yield c
+
+
+@pytest.fixture
+def auth_token(client):
+    resp = client.post("/api/v1/auth/admin/login", json={"password": "admin"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestBackupAPI:
+    """Integration tests for the backup API endpoints (sync TestClient)."""
+
+    def test_create_backup_endpoint(self, client, auth_token):
+        resp = client.post(
+            "/api/v1/backup/create",
+            json={"description": "API test backup"},
+            headers=_auth(auth_token),
+        )
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "backup_id" in data
+        assert data["message"] == "Backup created successfully"
+        assert data["size_bytes"] > 0
+
+    def test_create_backup_without_auth_fails(self, client):
+        resp = client.post("/api/v1/backup/create", json={"description": "Test"})
+        assert resp.status_code in (401, 403)
+
+    def test_list_backups_endpoint(self, client, auth_token):
+        client.post("/api/v1/backup/create", json={"description": "List test"},
+                    headers=_auth(auth_token))
+        resp = client.get("/api/v1/backup/list", headers=_auth(auth_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_get_backup_info_endpoint(self, client, auth_token):
+        created = client.post("/api/v1/backup/create", json={}, headers=_auth(auth_token)).json()
+        backup_id = created["backup_id"]
+        resp = client.get(f"/api/v1/backup/{backup_id}", headers=_auth(auth_token))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["backup_id"] == backup_id
+        assert data["integrity_ok"] is True
+
+    def test_get_nonexistent_backup_info_endpoint(self, client, auth_token):
+        resp = client.get("/api/v1/backup/nonexistent", headers=_auth(auth_token))
+        assert resp.status_code == 404
+
+    def test_delete_backup_endpoint(self, client, auth_token):
+        backup_id = client.post("/api/v1/backup/create", json={}, headers=_auth(auth_token)).json()["backup_id"]
+        resp = client.delete(f"/api/v1/backup/{backup_id}", headers=_auth(auth_token))
+        assert resp.status_code == 204
+        # Confirm it is gone.
+        assert client.get(f"/api/v1/backup/{backup_id}", headers=_auth(auth_token)).status_code == 404
+
+    def test_get_scheduler_status_endpoint(self, client, auth_token):
+        resp = client.get("/api/v1/backup/scheduler/status", headers=_auth(auth_token))
+        assert resp.status_code in (200, 503)
+        if resp.status_code == 200:
+            data = resp.json()
+            for key in ("enabled", "running", "interval_hours", "retention_days", "max_count"):
+                assert key in data
+
+    def test_trigger_backup_endpoint(self, client, auth_token):
+        resp = client.post("/api/v1/backup/scheduler/trigger", headers=_auth(auth_token))
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert "backup_id" in data and "message" in data
+        assert len(data["backup_id"]) == 15
+
+    def test_scheduler_endpoints_without_auth_fail(self, client):
+        assert client.get("/api/v1/backup/scheduler/status").status_code in (401, 403)
+        assert client.post("/api/v1/backup/scheduler/trigger").status_code in (401, 403)


### PR DESCRIPTION
Supersedes #12. That PR (the version Roland's install runs) conflicted against current `main` and carried agent cruft + an older oook auth attempt. This takes **only** the backup/restore feature and rewires it cleanly onto the hardened, auth-wired `main`. Closes #12 once merged.

## Feature

- `funkygibbon/backup.py` — `BackupService`: atomic `VACUUM INTO` backups including BLOBs, SHA-256 integrity, list/info/restore/delete.
- `funkygibbon/backup_scheduler.py` — APScheduler-based periodic backups + retention (by age and count).
- `funkygibbon/api/routers/backup.py` — admin-only REST endpoints.
- `app.py` wires the router + starts/stops the scheduler in lifespan; `config.py` adds `BACKUP_*` settings; `requirements.txt` adds `apscheduler`.

## Fixes made while grafting

- **Auth unified / insecure secret removed.** The backup router had its *own* `TokenManager` seeded with the `"development-secret-key"` fallback, so it couldn't verify tokens the auth router minted (resulted in a 500 / `None.get`). Every endpoint now depends on the shared `require_admin` — stricter than `require_auth`, no duplicate verifier, no hardcoded secret.
- **WAL-safe restore.** `restore_backup` replaced the main DB file but left the SQLite `-wal`/`-shm` sidecars, so the stale write-ahead log was replayed over the restored file and resurrected post-backup writes. It now removes the sidecars — proven by `test_restore_backup` (row count correctly returns to 1).

## Tests

`tests/test_backup.py` rewritten **fully synchronous** (no pytest-asyncio): async code is driven via `asyncio.run`, and each test gets an isolated absolute-path **NullPool** engine patched into `funkygibbon.database`, so backup/restore is deterministic (the shared relative-path pooled engine was bleeding DB files across tests). **30 backup tests pass; full funkygibbon suite: 162 passed.**

## Migration note

Roland's install runs the older backup/restore. The upgrade/migration (separate task) must carry that install onto this version — notably the WAL-safe restore and the unified admin auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)