### PR TITLE
sync: inbetweenies-v2 protocol correctness (server + client) to match PROTOCOL.md

### DIFF
--- a/blowing-off/blowingoff/sync/engine.py
+++ b/blowing-off/blowingoff/sync/engine.py
@@ -32,7 +32,7 @@ REVISION HISTORY:
 
 import asyncio
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any, Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 import json
@@ -131,8 +131,10 @@ class SyncEngine:
                 if await self._resolve_conflict(conflict):
                     resolved_count += 1
 
-            # Update sync metadata
-            await self.metadata_repo.update_sync_time(datetime.now(), self.client_id)
+            # Persist the SERVER's clock as our delta watermark (PROTOCOL.md §4),
+            # never the client's local time. We send this back as `since` next sync.
+            watermark = self._parse_server_time(sync_response.get("server_time"))
+            await self.metadata_repo.update_sync_time(watermark, self.client_id)
 
             # Calculate duration
             duration = (datetime.now() - start_time).total_seconds()
@@ -194,36 +196,46 @@ class SyncEngine:
             self._pending_sync_entities = set()
         self._pending_sync_entities.add(entity_id)
 
+    @staticmethod
+    def _parse_server_time(server_time: Optional[str]) -> datetime:
+        """Parse the response's server_time into a UTC-aware datetime.
+
+        Falls back to 'now' (UTC) only if the server omitted it (older server)."""
+        if server_time:
+            try:
+                parsed = datetime.fromisoformat(server_time.replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                return parsed.astimezone(timezone.utc)
+            except ValueError:
+                pass
+        return datetime.now(timezone.utc)
+
     async def _apply_single_change(self, change: Change) -> bool:
-        """Apply a single change from server."""
+        """Apply a single change from the server.
+
+        Creates, updates and deletes are all stored as entity versions — a delete
+        is a tombstone version (content.deleted=true), so applying it is the same
+        store operation as any other version (PROTOCOL.md §8). The local graph's
+        active views filter out tombstoned entities.
+        """
         if not self.graph_operations:
             return False
 
         try:
-            if change.operation == SyncOperation.DELETE:
-                # Delete entity
-                # Note: Graph operations might not have a delete method yet
-                return False  # Skip deletes for now
-            else:
-                # Create/Update entity
-                entity_data = change.data
-
-                # Convert to Entity object
-                entity = Entity(
-                    id=entity_data.get('id'),
-                    version=entity_data.get('version', ''),
-                    entity_type=EntityType(entity_data.get('entity_type', 'unknown')),
-                    name=entity_data.get('name', ''),
-                    content=entity_data.get('content', {}),
-                    source_type=SourceType(entity_data.get('source_type', SourceType.IMPORTED)),
-                    parent_versions=entity_data.get('parent_versions', []),
-                    user_id=entity_data.get('user_id', 'sync')
-                )
-
-                # Store entity
-                print(f"DEBUG: Applying change for entity {entity.id}: version={entity.version}, content={entity.content}")
-                await self.graph_operations.store_entity(entity)
-                return True
+            entity_data = change.data
+            entity = Entity(
+                id=entity_data.get('id'),
+                version=entity_data.get('version', ''),
+                entity_type=EntityType(entity_data.get('entity_type', 'unknown')),
+                name=entity_data.get('name', ''),
+                content=entity_data.get('content', {}),
+                source_type=SourceType(entity_data.get('source_type', SourceType.IMPORTED)),
+                parent_versions=entity_data.get('parent_versions', []),
+                user_id=entity_data.get('user_id', 'sync')
+            )
+            await self.graph_operations.store_entity(entity)
+            return True
 
         except Exception as e:
             print(f"Error applying change: {e}")
@@ -250,9 +262,14 @@ class SyncEngine:
         return response
 
     async def _resolve_conflict(self, conflict: Conflict) -> bool:
-        """Resolve a sync conflict."""
-        # For now, we'll use last-write-wins
-        # In a real implementation, this could be more sophisticated
+        """Acknowledge a conflict the server already resolved.
+
+        Conflict resolution is server-authoritative: the server runs the single
+        canonical algorithm (inbetweenies.sync.ConflictResolver — LWW + version
+        tiebreak, PROTOCOL.md §7) and sends the winning version in `changes`, which
+        we have already applied. The `conflicts` list is informational, so there is
+        nothing to resolve locally; we just count it as handled.
+        """
         return True
 
     def _convert_datetime_fields(self, data: Dict[str, Any]) -> Dict[str, Any]:

--- a/blowing-off/blowingoff/sync/protocol.py
+++ b/blowing-off/blowingoff/sync/protocol.py
@@ -65,8 +65,9 @@ USAGE:
 
 import json
 from typing import Dict, List, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import httpx
+from inbetweenies.models import Entity
 from inbetweenies.sync import Change, Conflict, SyncOperation
 from inbetweenies.sync import (
     VectorClock, EntityChange, SyncChange,
@@ -188,12 +189,17 @@ class InbetweeniesProtocol:
         for sync_change in sync_response.changes:
             if sync_change.entity:
                 # Convert to internal Change format
+                # Derive updated_at from the version (the wire EntityChange has no
+                # updated_at; the version encodes the UTC edit time). Falls back to
+                # now() only if the version can't be parsed.
+                updated_at = (Entity.version_timestamp(sync_change.entity.version)
+                              or datetime.now(timezone.utc))
                 change = Change(
                     entity_type=sync_change.entity.entity_type,
                     entity_id=sync_change.entity.id,
                     operation=SyncOperation(sync_change.change_type.lower()),
                     data=sync_change.entity.model_dump(),
-                    updated_at=datetime.now(),  # Use current time as updated_at
+                    updated_at=updated_at,
                     sync_id=sync_change.entity.version,
                     client_sync_id=None  # Server changes don't have client sync ID
                 )

--- a/blowing-off/tests/unit/test_sync_client_protocol.py
+++ b/blowing-off/tests/unit/test_sync_client_protocol.py
@@ -1,0 +1,67 @@
+"""Synchronous unit tests for the blowing-off client's sync wire handling.
+
+These cover the two correctness fixes that don't need a live server: deriving a
+server change's updated_at from its version (not the client clock), and parsing
+the response server_time into a UTC-aware watermark.
+"""
+
+from datetime import datetime, timezone
+
+from blowingoff.sync.protocol import InbetweeniesProtocol
+from blowingoff.sync.engine import SyncEngine
+from inbetweenies.models import Entity
+from inbetweenies.sync import SyncOperation
+
+VERSION = "2026-06-15T10:00:00.123456+00:00-000001-alice"
+
+
+def _response(change_type="update", content=None):
+    return {
+        "protocol_version": "inbetweenies-v2",
+        "sync_type": "full",
+        "changes": [{
+            "change_type": change_type,
+            "entity": {
+                "id": "e1", "version": VERSION, "entity_type": "device",
+                "name": "Lamp", "content": content or {}, "source_type": "manual",
+                "user_id": "alice", "parent_versions": [],
+            },
+            "relationships": [],
+        }],
+        "conflicts": [],
+        "server_time": "2026-06-15T10:00:01+00:00",
+    }
+
+
+def _protocol():
+    return InbetweeniesProtocol("http://server", "token", "client-1")
+
+
+def test_parse_sync_delta_derives_updated_at_from_version():
+    changes, conflicts = _protocol().parse_sync_delta(_response())
+    assert len(changes) == 1
+    # updated_at comes from the version timestamp, NOT datetime.now().
+    assert changes[0].updated_at == Entity.version_timestamp(VERSION)
+    assert changes[0].updated_at.tzinfo is not None
+    assert not conflicts
+
+
+def test_parse_sync_delta_marks_tombstone_as_delete():
+    changes, _ = _protocol().parse_sync_delta(_response("delete", content={"deleted": True}))
+    assert changes[0].operation == SyncOperation.DELETE
+    assert changes[0].data["content"]["deleted"] is True
+
+
+def test_parse_server_time_handles_offset_z_naive_and_missing():
+    # +00:00 offset
+    t1 = SyncEngine._parse_server_time("2026-06-15T10:00:01+00:00")
+    assert t1.tzinfo is not None and t1.isoformat() == "2026-06-15T10:00:01+00:00"
+    # trailing Z
+    t2 = SyncEngine._parse_server_time("2026-06-15T10:00:01Z")
+    assert t2 == t1
+    # naive -> assumed UTC
+    t3 = SyncEngine._parse_server_time("2026-06-15T10:00:01")
+    assert t3 == t1
+    # missing -> falls back to an aware "now"
+    t4 = SyncEngine._parse_server_time(None)
+    assert t4.tzinfo is not None

--- a/funkygibbon/api/sync.py
+++ b/funkygibbon/api/sync.py
@@ -8,16 +8,15 @@ between FunkyGibbon server and clients.
 from typing import List, Dict, Optional
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from funkygibbon.database import get_db
-from funkygibbon.sync.versioning import VersionManager
-from funkygibbon.sync.conflict_resolution import ConflictResolver, ConflictStrategy
-from funkygibbon.sync.delta import DeltaSyncEngine
-from inbetweenies.models import Entity, EntityRelationship, EntityType
+from inbetweenies.models import Entity, EntityRelationship, EntityType, SourceType
 from inbetweenies.sync import (
     VectorClock, EntityChange, RelationshipChange, SyncChange,
-    SyncFilters, SyncRequest, ConflictInfo, SyncStats, SyncResponse
+    SyncFilters, SyncRequest, ConflictInfo, SyncStats, SyncResponse,
+    ConflictResolver,
 )
 
 
@@ -25,214 +24,198 @@ from inbetweenies.sync import (
 router = APIRouter(prefix="/api/v1/sync", tags=["sync"])
 
 
+def _to_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Normalize a datetime to timezone-aware UTC (None passes through)."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 class SyncHandler:
-    """Handle sync protocol requests"""
+    """Handle sync protocol requests (inbetweenies-v2, see PROTOCOL.md).
+
+    Entities are immutable and versioned: every change is a new version row, a
+    delete is a tombstone version (``content.deleted = true``). Delta sync is
+    stateless — the client supplies ``filters.since`` (the ``server_time`` it
+    persisted from the previous response) and the server returns the current
+    state of everything with ``updated_at`` strictly greater than it.
+    """
 
     def __init__(self, db_session: AsyncSession):
         self.db_session = db_session
-        self.version_manager = VersionManager(db_session)
-        self.conflict_resolver = ConflictResolver()
-        self.delta_engine = DeltaSyncEngine(db_session)
 
     async def handle_sync_request(self, request: SyncRequest) -> SyncResponse:
-        """Process sync request and return changes"""
+        """Process sync request and return changes."""
         start_time = datetime.now(timezone.utc)
 
-        # Validate protocol version
         if request.protocol_version != "inbetweenies-v2":
             raise HTTPException(status_code=400, detail="Unsupported protocol version")
 
-        # Process incoming changes
-        conflicts = []
+        # --- Apply incoming (client -> server) changes ---
+        conflicts: List[ConflictInfo] = []
         entities_synced = 0
         relationships_synced = 0
 
         for change in request.changes:
             if change.change_type == "create":
-                await self._handle_create(change)
+                await self._apply_incoming(change, conflicts)
                 entities_synced += 1
             elif change.change_type == "update":
-                conflict = await self._handle_update(change)
-                if conflict:
-                    conflicts.append(conflict)
+                await self._apply_incoming(change, conflicts)
                 entities_synced += 1
             elif change.change_type == "delete":
                 await self._handle_delete(change)
                 entities_synced += 1
-
-            # Process relationships
             relationships_synced += len(change.relationships)
 
-        # Get changes to send back based on sync type
-        response_changes = []
+        # server_time is the watermark the client persists and sends back as the
+        # next `since`. Capture it now; everything applied above is <= it.
+        server_time = datetime.now(timezone.utc)
+
+        # --- Compute outgoing (server -> client) changes ---
+        latest = await self._latest_entities()
+        entities = list(latest.values())
 
         if request.sync_type == "delta":
-            # Get last sync time for device
-            last_sync = self.delta_engine.get_last_sync_time(request.device_id)
-            if not last_sync:
-                # First sync, use full sync
-                last_sync = datetime.min.replace(tzinfo=timezone.utc)
+            since = _to_utc(request.filters.since) if (request.filters and request.filters.since) else None
+            if since is not None:
+                # Strictly greater than `since` (exclusive lower bound, §4).
+                entities = [e for e in entities
+                            if (_to_utc(e.updated_at) or datetime.min.replace(tzinfo=timezone.utc)) > since]
 
-            # Calculate delta
-            entity_types = None
-            if request.filters and request.filters.entity_types:
-                entity_types = [EntityType(et) for et in request.filters.entity_types]
+        # Filters (apply to both full and delta).
+        if request.filters:
+            if request.filters.entity_types:
+                wanted = {EntityType(et) for et in request.filters.entity_types}
+                entities = [e for e in entities if e.entity_type in wanted]
+            if request.filters.modified_by:
+                wanted_users = set(request.filters.modified_by)
+                entities = [e for e in entities if e.user_id in wanted_users]
 
-            delta = await self.delta_engine.calculate_delta(last_sync, entity_types)
+        response_changes = []
+        for entity in entities:
+            deleted = bool((entity.content or {}).get("deleted"))
+            response_changes.append(SyncChange(
+                change_type="delete" if deleted else "update",
+                entity=self._entity_to_change(entity),
+            ))
 
-            # Convert delta to changes
-            for entity in delta.added_entities:
-                response_changes.append(SyncChange(
-                    change_type="create",
-                    entity=self._entity_to_change(entity)
-                ))
-
-            for entity in delta.modified_entities:
-                response_changes.append(SyncChange(
-                    change_type="update",
-                    entity=self._entity_to_change(entity)
-                ))
-
-        elif request.sync_type == "full":
-            # Return all entities
-            entities = await self._get_all_entities(request.filters)
-            for entity in entities:
-                response_changes.append(SyncChange(
-                    change_type="create",
-                    entity=self._entity_to_change(entity)
-                ))
-
-        # Update sync time
-        self.delta_engine.update_last_sync_time(request.device_id, datetime.now(timezone.utc))
-
-        # Calculate duration
         duration_ms = (datetime.now(timezone.utc) - start_time).total_seconds() * 1000
 
-        # Build response
         return SyncResponse(
             sync_type=request.sync_type,
             changes=response_changes,
             conflicts=conflicts,
-            vector_clock=request.vector_clock,  # Echo back for now
+            vector_clock=request.vector_clock,  # RESERVED — echoed, never read
+            server_time=server_time.isoformat(),
             sync_stats=SyncStats(
                 entities_synced=entities_synced,
                 relationships_synced=relationships_synced,
                 conflicts_resolved=len(conflicts),
-                duration_ms=duration_ms
-            )
+                duration_ms=duration_ms,
+            ),
         )
 
-    async def _handle_create(self, change: SyncChange):
-        """Handle entity creation"""
-        if not change.entity:
-            return
+    async def _latest_entities(self) -> Dict[str, Entity]:
+        """Return the latest (lexically greatest version) row per entity id."""
+        result = await self.db_session.execute(select(Entity))
+        latest: Dict[str, Entity] = {}
+        for entity in result.scalars().all():
+            current = latest.get(entity.id)
+            if current is None or entity.version > current.version:
+                latest[entity.id] = entity
+        return latest
 
-        # Check if entity already exists - get latest version
-        from sqlalchemy import select
-        stmt = select(Entity).where(Entity.id == change.entity.id).order_by(Entity.created_at.desc()).limit(1)
-        result = await self.db_session.execute(stmt)
-        existing = result.scalar_one_or_none()
-        if existing:
-            # Already exists, this is a conflict
-            # For now, skip creation
-            return
+    async def _insert_version(self, change: SyncChange, *, deleted: bool = False) -> None:
+        """Insert a new immutable version row (idempotent on (id, version))."""
+        existing_row = await self.db_session.get(
+            Entity, (change.entity.id, change.entity.version)
+        )
+        if existing_row is not None:
+            return  # already applied this exact version
 
-        # Create new entity
-        from inbetweenies.models import SourceType as ST
+        content = dict(change.entity.content or {})
+        if deleted:
+            content["deleted"] = True
+        now = datetime.now(timezone.utc)
         entity = Entity(
             id=change.entity.id,
             version=change.entity.version,
             entity_type=EntityType(change.entity.entity_type),
             name=change.entity.name,
-            content=change.entity.content,
-            source_type=ST(change.entity.source_type),
+            content=content,
+            source_type=SourceType(change.entity.source_type),
             user_id=change.entity.user_id,
-            parent_versions=change.entity.parent_versions
+            parent_versions=change.entity.parent_versions or [],
+            created_at=now,
+            updated_at=now,
         )
-
         self.db_session.add(entity)
         await self.db_session.commit()
 
-    async def _handle_update(self, change: SyncChange) -> Optional[ConflictInfo]:
-        """Handle entity update"""
-        if not change.entity:
-            return None
-
-        # Get existing entity - need to get the latest version
-        from sqlalchemy import select
-        stmt = select(Entity).where(Entity.id == change.entity.id).order_by(Entity.created_at.desc()).limit(1)
-        result = await self.db_session.execute(stmt)
-        existing = result.scalar_one_or_none()
-        if not existing:
-            # Doesn't exist, create it
-            await self._handle_create(change)
-            return None
-
-        # Check for conflict
-        if existing.version != change.entity.parent_versions[0] if change.entity.parent_versions else None:
-            # Version conflict
-            from inbetweenies.models import SourceType as ST
-            remote_entity = Entity(
-                id=change.entity.id,
-                version=change.entity.version,
-                entity_type=EntityType(change.entity.entity_type),
-                name=change.entity.name,
-                content=change.entity.content,
-                source_type=ST(change.entity.source_type),
-                user_id=change.entity.user_id,
-                parent_versions=change.entity.parent_versions
-            )
-
-            # Resolve conflict
-            resolution = self.conflict_resolver.resolve_conflict(
-                existing, remote_entity, ConflictStrategy.MERGE
-            )
-
-            if resolution.resolved_entity:
-                # Update with resolved entity
-                existing.version = resolution.resolved_entity.version
-                existing.name = resolution.resolved_entity.name
-                existing.content = resolution.resolved_entity.content
-                existing.parent_versions = resolution.resolved_entity.parent_versions
-                existing.updated_at = datetime.now(timezone.utc)
-
-                await self.db_session.commit()
-
-                return ConflictInfo(
-                    entity_id=change.entity.id,
-                    local_version=existing.version,
-                    remote_version=change.entity.version,
-                    resolution_strategy="merge",
-                    resolved_version=resolution.resolved_entity.version
-                )
-        else:
-            # No conflict, update
-            existing.version = change.entity.version
-            existing.name = change.entity.name
-            existing.content = change.entity.content
-            existing.parent_versions = change.entity.parent_versions
-            existing.updated_at = datetime.now(timezone.utc)
-
-            await self.db_session.commit()
-
-        return None
-
-    async def _handle_delete(self, change: SyncChange):
-        """Handle entity deletion"""
+    async def _apply_incoming(self, change: SyncChange, conflicts: List[ConflictInfo]) -> None:
+        """Apply a create/update: fast-forward if based on our latest, else resolve."""
         if not change.entity:
             return
 
-        # Get entity to delete - need to find the latest version
-        from sqlalchemy import select
-        stmt = select(Entity).where(Entity.id == change.entity.id).order_by(Entity.created_at.desc()).limit(1)
-        result = await self.db_session.execute(stmt)
-        entity = result.scalar_one_or_none()
-        if entity:
-            await self.db_session.delete(entity)
-            await self.db_session.commit()
+        latest = await self._latest_entities()
+        existing = latest.get(change.entity.id)
+
+        if existing is None:
+            await self._insert_version(change)
+            return
+
+        if existing.version == change.entity.version:
+            return  # idempotent re-send
+
+        parents = change.entity.parent_versions or []
+        if existing.version in parents:
+            await self._insert_version(change)  # fast-forward
+            return
+
+        # Concurrent edit -> canonical resolution (LWW + version tiebreak).
+        local = {"updated_at": _to_utc(existing.updated_at), "version": existing.version}
+        remote = {
+            "updated_at": Entity.version_timestamp(change.entity.version) or _to_utc(existing.updated_at),
+            "version": change.entity.version,
+        }
+        resolution = ConflictResolver.resolve(local, remote)
+        remote_wins = resolution.winner.get("version") == change.entity.version
+
+        if remote_wins:
+            await self._insert_version(change)
+            resolved_version = change.entity.version
+        else:
+            resolved_version = existing.version
+
+        conflicts.append(ConflictInfo(
+            entity_id=change.entity.id,
+            local_version=existing.version,
+            remote_version=change.entity.version,
+            resolution_strategy=resolution.reason,
+            resolved_version=resolved_version,
+        ))
+
+    async def _handle_delete(self, change: SyncChange) -> None:
+        """Apply a delete as a tombstone version (content.deleted = true, §8)."""
+        if not change.entity:
+            return
+        latest = await self._latest_entities()
+        existing = latest.get(change.entity.id)
+        if existing is None:
+            return  # nothing to delete
+        if bool((existing.content or {}).get("deleted")):
+            return  # already tombstoned
+        # If the client didn't set the prior version as a parent, record it so the
+        # tombstone supersedes the latest known version.
+        if existing.version not in (change.entity.parent_versions or []):
+            change.entity.parent_versions = [existing.version]
+        await self._insert_version(change, deleted=True)
 
     def _entity_to_change(self, entity: Entity) -> EntityChange:
-        """Convert entity to change format"""
+        """Convert a stored entity to its wire EntityChange."""
         return EntityChange(
             id=entity.id,
             version=entity.version,
@@ -241,28 +224,8 @@ class SyncHandler:
             content=entity.content or {},
             source_type=entity.source_type.value,
             user_id=entity.user_id,
-            parent_versions=entity.parent_versions
+            parent_versions=entity.parent_versions or [],
         )
-
-    async def _get_all_entities(self, filters: Optional[SyncFilters]) -> List[Entity]:
-        """Get all entities with optional filters"""
-        from sqlalchemy import select
-
-        query = select(Entity)
-
-        if filters:
-            if filters.entity_types:
-                entity_types = [EntityType(et) for et in filters.entity_types]
-                query = query.where(Entity.entity_type.in_(entity_types))
-
-            if filters.since:
-                query = query.where(Entity.updated_at >= filters.since)
-
-            if filters.modified_by:
-                query = query.where(Entity.user_id.in_(filters.modified_by))
-
-        result = await self.db_session.execute(query)
-        return list(result.scalars().all())
 
 
 @router.post("/", response_model=SyncResponse)
@@ -277,29 +240,24 @@ async def sync_data(
 
 @router.get("/status")
 async def sync_status(
-    device_id: str = Query(..., description="Device ID to check sync status"),
+    device_id: str = Query(..., description="Device ID (informational)"),
     db: AsyncSession = Depends(get_db)
 ):
-    """Get sync status for a device"""
-    delta_engine = DeltaSyncEngine(db)
-    last_sync = delta_engine.get_last_sync_time(device_id)
-
+    """Sync status. Delta sync is stateless (the client holds its own watermark
+    via the response `server_time`), so this just reports the current server time
+    the client can use as a `since` baseline."""
     return {
         "device_id": device_id,
-        "last_sync": last_sync.isoformat() if last_sync else None,
-        "protocol_version": "inbetweenies-v2"
+        "server_time": datetime.now(timezone.utc).isoformat(),
+        "protocol_version": "inbetweenies-v2",
     }
 
 
 @router.get("/conflicts")
-async def get_pending_conflicts(
-    db: AsyncSession = Depends(get_db)
-):
-    """Get all pending manual conflict resolutions"""
-    conflict_resolver = ConflictResolver()
-    return {
-        "conflicts": conflict_resolver.get_pending_resolutions()
-    }
+async def get_pending_conflicts(db: AsyncSession = Depends(get_db)):
+    """Conflicts are resolved automatically and deterministically during sync
+    (PROTOCOL.md §7); there is no manual-resolution queue. Always empty."""
+    return {"conflicts": []}
 
 
 @router.post("/conflicts/{conflict_id}/resolve")
@@ -308,11 +266,8 @@ async def resolve_conflict(
     resolution: Dict,
     db: AsyncSession = Depends(get_db)
 ):
-    """Manually resolve a conflict"""
-    conflict_resolver = ConflictResolver()
-    success = conflict_resolver.resolve_manual_conflict(conflict_id, resolution)
-
-    if not success:
-        raise HTTPException(status_code=404, detail="Conflict not found")
-
-    return {"status": "resolved", "conflict_id": conflict_id}
+    """Manual conflict resolution is not supported — conflicts auto-resolve."""
+    raise HTTPException(
+        status_code=404,
+        detail="No manual conflict queue; conflicts auto-resolve during sync.",
+    )

--- a/funkygibbon/sync/versioning.py
+++ b/funkygibbon/sync/versioning.py
@@ -86,9 +86,8 @@ class VersionManager:
         self.db_session = db_session
 
     def create_version(self, entity: Entity, parent_versions: List[str]) -> str:
-        """Create new version with parent tracking"""
-        timestamp = datetime.now(timezone.utc).isoformat()
-        return f"{timestamp}Z-{entity.user_id}"
+        """Create a new version string (canonical format, see PROTOCOL.md §2)."""
+        return Entity.create_version(entity.user_id)
 
     async def get_version_history(self, entity_id: str) -> List[Entity]:
         """Get complete version history for entity"""

--- a/funkygibbon/tests/test_sync.py
+++ b/funkygibbon/tests/test_sync.py
@@ -58,8 +58,12 @@ class TestVersionManager:
 
         version = version_manager.create_version(sample_entity, [])
 
-        assert version.endswith(f"Z-{sample_entity.user_id}")
+        # Canonical format {utc-iso8601}-{counter:06d}-{user_id}: no doubled Z,
+        # ends with the user id, and parses back to a UTC timestamp (PROTOCOL.md §2).
+        assert "Z-" not in version
+        assert version.endswith(f"-{sample_entity.user_id}")
         assert "T" in version  # ISO format timestamp
+        assert Entity.version_timestamp(version) is not None
 
     @pytest.mark.asyncio
     async def test_merge_versions(self, async_session):

--- a/funkygibbon/tests/test_sync_protocol.py
+++ b/funkygibbon/tests/test_sync_protocol.py
@@ -1,0 +1,194 @@
+"""Spec-correctness tests for the inbetweenies-v2 sync protocol (PROTOCOL.md).
+
+Synchronous throughout: pure-function units for the version string + canonical
+conflict resolver, and endpoint tests driven through a sync TestClient over an
+isolated NullPool database (see test_backup for why the shared engine is patched).
+"""
+
+import asyncio
+import time
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import NullPool
+from fastapi.testclient import TestClient
+
+import funkygibbon.database as dbmod
+from funkygibbon.config import settings
+from funkygibbon.api.app import create_app
+from inbetweenies.models import Entity
+from inbetweenies.sync import ConflictResolver
+
+
+# --------------------------------------------------------------------------- #
+# Pure-function units
+# --------------------------------------------------------------------------- #
+def test_version_format_is_canonical_and_monotonic():
+    v1 = Entity.create_version("alice")
+    v2 = Entity.create_version("alice")
+    # No doubled Z, ends with user id, parses to a UTC timestamp.
+    assert "Z-" not in v1 and "+00:00" in v1
+    assert v1.endswith("-alice")
+    assert Entity.version_timestamp(v1) is not None
+    # Monotonic: later call sorts lexically greater (counter and/or time advance).
+    assert v2 > v1
+
+
+def test_version_timestamp_handles_hyphenated_user_and_legacy_z():
+    canonical = "2026-06-15T13:37:41.613629+00:00-000001-local-client"
+    legacy_z = "2026-05-08T07:57:54.734914+00:00Z-000000-agent"
+    assert Entity.version_timestamp(canonical).isoformat() == "2026-06-15T13:37:41.613629+00:00"
+    assert Entity.version_timestamp(legacy_z).isoformat() == "2026-05-08T07:57:54.734914+00:00"
+
+
+def test_conflict_resolver_last_write_wins():
+    local = {"updated_at": "2026-06-15T10:00:00+00:00", "version": "a"}
+    remote = {"updated_at": "2026-06-15T10:00:05+00:00", "version": "b"}  # 5s newer
+    res = ConflictResolver.resolve(local, remote)
+    assert res.winner is remote and "newer" in res.reason
+
+
+def test_conflict_resolver_tiebreak_on_version_within_one_second():
+    # Same instant: the lexically greater version must win (not sync_id).
+    base = "2026-06-15T10:00:00+00:00"
+    local = {"updated_at": base, "version": base + "-000001-alice"}
+    remote = {"updated_at": base, "version": base + "-000002-alice"}  # greater
+    res = ConflictResolver.resolve(local, remote)
+    assert res.winner is remote and "version" in res.reason
+    # And symmetric: greater local wins.
+    res2 = ConflictResolver.resolve(remote, local)  # now `remote` arg is the greater one
+    assert res2.winner is remote
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint tests (isolated DB + sync TestClient)
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "funkygibbon.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    engine = create_async_engine(url, connect_args={"timeout": 5}, poolclass=NullPool)
+    sm = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(dbmod, "engine", engine)
+    monkeypatch.setattr(dbmod, "async_session", sm)
+    monkeypatch.setattr(settings, "database_url", url)
+    monkeypatch.chdir(tmp_path)
+    yield
+    asyncio.run(engine.dispose())
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(settings, "backup_schedule_enabled", False)
+    with TestClient(create_app()) as c:
+        yield c
+
+
+@pytest.fixture
+def headers(client):
+    token = client.post("/api/v1/auth/admin/login", json={"password": "admin"}).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _change(change_type, *, id, version, name="N", content=None,
+            etype="device", user="alice", parents=None):
+    return {
+        "change_type": change_type,
+        "entity": {
+            "id": id, "version": version, "entity_type": etype, "name": name,
+            "content": content or {}, "source_type": "manual", "user_id": user,
+            "parent_versions": parents or [],
+        },
+        "relationships": [],
+    }
+
+
+def _sync(client, headers, sync_type, changes=None, since=None, device="dev1", user="alice"):
+    body = {
+        "protocol_version": "inbetweenies-v2", "device_id": device, "user_id": user,
+        "sync_type": sync_type, "changes": changes or [],
+    }
+    if since is not None:
+        body["filters"] = {"since": since}
+    return client.post("/api/v1/sync/", json=body, headers=headers)
+
+
+def test_sync_requires_auth(client):
+    resp = client.post("/api/v1/sync/", json={
+        "protocol_version": "inbetweenies-v2", "device_id": "d", "user_id": "u",
+        "sync_type": "full", "changes": [],
+    })
+    assert resp.status_code in (401, 403)
+
+
+def test_full_sync_returns_server_time_and_created_entity(client, headers):
+    eid, ver = "e1", Entity.create_version("alice")
+    resp = _sync(client, headers, "full", [_change("create", id=eid, version=ver, name="Lamp")])
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["server_time"]  # REQUIRED watermark
+    ids = [c["entity"]["id"] for c in data["changes"]]
+    assert eid in ids
+
+
+def test_delta_since_is_exclusive(client, headers):
+    # Create A, take server_time, then create B and delta from that watermark.
+    va = Entity.create_version("alice")
+    r1 = _sync(client, headers, "full", [_change("create", id="A", version=va, name="A")])
+    watermark = r1.json()["server_time"]
+    time.sleep(0.01)
+    vb = Entity.create_version("alice")
+    r2 = _sync(client, headers, "delta", [_change("create", id="B", version=vb, name="B")], since=watermark)
+    ids = [c["entity"]["id"] for c in r2.json()["changes"]]
+    assert "B" in ids       # changed after the watermark
+    assert "A" not in ids   # at/below the watermark — excluded (strict >)
+
+
+def test_update_fast_forward_creates_new_version(client, headers):
+    v1 = Entity.create_version("alice")
+    _sync(client, headers, "full", [_change("create", id="X", version=v1, name="v1")])
+    v2 = Entity.create_version("alice")
+    _sync(client, headers, "full",
+          [_change("update", id="X", version=v2, name="v2", parents=[v1])])
+    # Full sync now reports X at v2 (latest version wins).
+    data = _sync(client, headers, "full").json()
+    x = [c["entity"] for c in data["changes"] if c["entity"]["id"] == "X"][0]
+    assert x["version"] == v2 and x["name"] == "v2"
+
+
+def test_concurrent_update_conflict_resolved_by_version(client, headers):
+    v1 = Entity.create_version("alice")
+    _sync(client, headers, "full", [_change("create", id="Y", version=v1, name="v1")])
+    v2 = Entity.create_version("alice")
+    _sync(client, headers, "full", [_change("update", id="Y", version=v2, name="v2", parents=[v1])])
+    # A stale client edits from v1 (never saw v2) with a *greater* version v3.
+    v3 = Entity.create_version("alice")
+    resp = _sync(client, headers, "full",
+                 [_change("update", id="Y", version=v3, name="v3", parents=[v1])])
+    conflicts = resp.json()["conflicts"]
+    assert conflicts and conflicts[0]["entity_id"] == "Y"
+    assert conflicts[0]["resolved_version"] == v3  # greater version wins the tiebreak
+    latest = [c["entity"] for c in _sync(client, headers, "full").json()["changes"]
+              if c["entity"]["id"] == "Y"][0]
+    assert latest["version"] == v3
+
+
+def test_delete_creates_tombstone_and_propagates(client, headers):
+    v1 = Entity.create_version("alice")
+    _sync(client, headers, "full", [_change("create", id="Z", version=v1, name="gone")])
+    vt = Entity.create_version("alice")
+    resp = _sync(client, headers, "full",
+                 [_change("delete", id="Z", version=vt, name="gone", parents=[v1])])
+    z = [c for c in resp.json()["changes"] if c["entity"]["id"] == "Z"][0]
+    assert z["change_type"] == "delete"
+    assert z["entity"]["content"].get("deleted") is True
+
+
+def test_idempotent_resend_is_noop(client, headers):
+    v1 = Entity.create_version("alice")
+    change = _change("create", id="I", version=v1, name="once")
+    _sync(client, headers, "full", [change])
+    _sync(client, headers, "full", [change])  # same (id, version) again
+    data = _sync(client, headers, "full").json()
+    matches = [c for c in data["changes"] if c["entity"]["id"] == "I"]
+    assert len(matches) == 1  # not duplicated

--- a/inbetweenies/models/entity.py
+++ b/inbetweenies/models/entity.py
@@ -5,6 +5,8 @@ This module defines the generic Entity model that can represent any node
 in the knowledge graph (homes, rooms, devices, procedures, etc.).
 """
 
+import itertools
+import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Any, Optional
@@ -12,6 +14,10 @@ from sqlalchemy import Column, String, JSON, DateTime, Enum as SQLEnum
 from sqlalchemy.orm import relationship
 
 from .base import Base, InbetweeniesTimestampMixin
+
+# Monotonic per-process counter for version-string tiebreaking. next() is atomic
+# under CPython's GIL, so this is safe across threads without extra locking.
+_version_counter = itertools.count()
 
 
 class EntityType(str, Enum):
@@ -112,13 +118,39 @@ class Entity(Base, InbetweeniesTimestampMixin):
 
     @classmethod
     def create_version(cls, user_id: str) -> str:
-        """Generate a new version string for immutable versioning"""
-        import time
-        import random
+        """Generate a version string: ``{utc-iso8601}-{counter:06d}-{user_id}``.
+
+        The timestamp is timezone-aware UTC ISO-8601 (``+00:00`` offset, no extra
+        trailing ``Z``). The counter is a 6-digit monotonic per-process tiebreaker
+        that disambiguates edits made within the same microsecond. Versions sort
+        lexically, and because the timestamp prefix is fixed-width UTC, lexical
+        order equals chronological order. See inbetweenies/PROTOCOL.md §2.
+        """
         timestamp = datetime.now(timezone.utc).isoformat()
-        # Add nanosecond precision to ensure uniqueness on Windows
-        nanos = int(time.perf_counter_ns() % 1000000)
-        return f"{timestamp}Z-{nanos:06d}-{user_id}"
+        counter = next(_version_counter) % 1000000
+        return f"{timestamp}-{counter:06d}-{user_id}"
+
+    @staticmethod
+    def version_timestamp(version: str) -> Optional[datetime]:
+        """Parse the UTC timestamp out of a version string, or None if it can't.
+
+        Version is ``{utc-iso8601}-{counter:06d}-{user_id}``. The ISO-8601 prefix
+        ends at the UTC offset (``+00:00``); the counter and (possibly hyphenated)
+        user id follow. We anchor on the offset rather than splitting on ``-`` so a
+        hyphenated user id (e.g. ``local-client``) parses correctly, and a stray
+        legacy trailing ``Z`` is tolerated. Used to derive a remote edit's time for
+        conflict resolution, since the wire EntityChange carries no updated_at.
+        """
+        match = re.match(r"^(.*?[+-]\d{2}:\d{2})", version)
+        if not match:
+            return None
+        try:
+            parsed = datetime.fromisoformat(match.group(1))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
 
     def create_new_version(self, user_id: str, changes: Dict[str, Any]) -> "Entity":
         """

--- a/inbetweenies/sync/conflict.py
+++ b/inbetweenies/sync/conflict.py
@@ -48,16 +48,24 @@ class ConflictResolution:
 
 
 class ConflictResolver:
-    """Handles last-write-wins conflict resolution for the Inbetweenies protocol."""
+    """The single canonical conflict resolver for the Inbetweenies protocol.
+
+    Last-write-wins on ``updated_at`` (UTC), and when two edits land within a
+    1-second window, tiebreak on the ``version`` string (lexically greater wins).
+    The version encodes UTC time + a monotonic counter + user id, so it is a
+    stable, wire-visible tiebreaker — unlike ``sync_id``, which is not part of the
+    wire model. This is the one algorithm; clients and server MUST share it
+    (PROTOCOL.md §7).
+    """
 
     @staticmethod
     def resolve(local: Dict[str, Any], remote: Dict[str, Any]) -> ConflictResolution:
         """
-        Resolve conflicts using last-write-wins strategy.
+        Resolve conflicts using last-write-wins with a version tiebreak.
 
         Args:
-            local: Local entity data
-            remote: Remote entity data
+            local: Local entity data (must have ``updated_at`` and ``version``)
+            remote: Remote entity data (must have ``updated_at`` and ``version``)
 
         Returns:
             ConflictResolution with winner and reason
@@ -89,21 +97,21 @@ class ConflictResolver:
         # Calculate millisecond difference
         diff_ms = int((remote_ts - local_ts).total_seconds() * 1000)
 
-        if abs(diff_ms) < 1000:  # Within 1 second, use sync_id as tiebreaker
-            remote_sync_id = remote.get("sync_id") or ""
-            local_sync_id = local.get("sync_id") or ""
-            if remote_sync_id > local_sync_id:
+        if abs(diff_ms) < 1000:  # Within 1 second: tiebreak on the version string
+            remote_version = remote.get("version") or ""
+            local_version = local.get("version") or ""
+            if remote_version > local_version:
                 return ConflictResolution(
                     winner=remote,
                     loser=local,
-                    reason="timestamps equal, remote has higher sync_id",
+                    reason="timestamps within 1s, remote has greater version",
                     timestamp_diff_ms=diff_ms
                 )
             else:
                 return ConflictResolution(
                     winner=local,
                     loser=remote,
-                    reason="timestamps equal, local has higher sync_id",
+                    reason="timestamps within 1s, local has greater version",
                     timestamp_diff_ms=diff_ms
                 )
 

--- a/inbetweenies/sync/protocol.py
+++ b/inbetweenies/sync/protocol.py
@@ -91,3 +91,6 @@ class SyncResponse(BaseModel):
     vector_clock: VectorClock = Field(default_factory=VectorClock)
     cursor: Optional[str] = None
     sync_stats: SyncStats = Field(default_factory=SyncStats)
+    # UTC ISO-8601 server clock at response time. The client persists this and
+    # sends it back as filters.since on the next delta sync (PROTOCOL.md §4).
+    server_time: Optional[str] = None

--- a/inbetweenies/tests/unit/test_conflict_resolution.py
+++ b/inbetweenies/tests/unit/test_conflict_resolution.py
@@ -59,21 +59,21 @@ class TestConflictResolver:
         assert "local has newer timestamp" in resolution.reason
         assert resolution.timestamp_diff_ms < 0
 
-    def test_resolve_with_same_timestamp_sync_id_tiebreaker(self):
-        """Test resolution using sync_id when timestamps are equal."""
+    def test_resolve_with_same_timestamp_version_tiebreaker(self):
+        """Within 1s the greater version string wins (canonical, PROTOCOL.md §7)."""
         base_time = datetime.now(timezone.utc)
 
         local = {
             "id": "test-entity",
             "updated_at": base_time,
-            "sync_id": "aaa-sync",
+            "version": "2026-06-15T10:00:00+00:00-000001-alice",
             "content": {"value": 100}
         }
 
         remote = {
             "id": "test-entity",
             "updated_at": base_time,
-            "sync_id": "bbb-sync",  # Higher lexicographically
+            "version": "2026-06-15T10:00:00+00:00-000002-alice",  # greater
             "content": {"value": 200}
         }
 
@@ -81,7 +81,7 @@ class TestConflictResolver:
 
         assert resolution.winner == remote
         assert resolution.loser == local
-        assert "sync_id" in resolution.reason
+        assert "version" in resolution.reason
         assert abs(resolution.timestamp_diff_ms) < 1000
 
     def test_resolve_with_string_timestamps(self):
@@ -155,21 +155,21 @@ class TestConflictResolver:
         assert "remote has newer timestamp" in resolution.reason
         assert resolution.timestamp_diff_ms == 1800000  # 30 minutes in milliseconds
 
-    def test_resolve_with_none_sync_id(self):
-        """Test resolution when sync_id is None or missing."""
+    def test_resolve_with_missing_version(self):
+        """Within 1s and both versions absent/empty, local wins deterministically."""
         base_time = datetime.now(timezone.utc)
 
         local = {
             "id": "test-entity",
             "updated_at": base_time,
-            "sync_id": None,
+            "version": None,
             "content": {"value": 100}
         }
 
         remote = {
             "id": "test-entity",
             "updated_at": base_time,
-            # Missing sync_id
+            # Missing version
             "content": {"value": 200}
         }
 
@@ -178,7 +178,7 @@ class TestConflictResolver:
         # With both None/missing, local wins (empty string comparison)
         assert resolution.winner == local
         assert resolution.loser == remote
-        assert "sync_id" in resolution.reason
+        assert "version" in resolution.reason
 
     def test_resolve_with_mixed_timestamp_types(self):
         """Test resolution with mixed datetime and string timestamps."""


### PR DESCRIPTION
Makes the reference implementation conform to `inbetweenies/PROTOCOL.md` (§2, §4, §6, §7, §8). Two commits: server/shared-model, then client. The `funkygibbon migrate` data tool that re-versions existing rows follows in a separate PR.

## Server + shared model

- **Version string (§2)** — `Entity.create_version` drops the doubled `Z` and uses a real monotonic per-process counter (was `perf_counter_ns()%1e6`). `VersionManager` delegates to it (one implementation). New `Entity.version_timestamp()` parses the UTC time back out, tolerating a hyphenated user id and a legacy trailing `Z`.
- **`server_time` (§4)** — added to `SyncResponse`; the handler returns it as the watermark the client persists and replays as the next `since`.
- **Stateless delta (§4)** — removed the in-memory per-device watermark (reset every request / on restart, degraded delta→full). Delta is driven by `filters.since` with a **strict `>`** bound. Fits the single-house / few-clients deployment — no scale machinery.
- **Canonical conflict resolver (§7)** — one algorithm in `inbetweenies.sync`: LWW on `updated_at`, tiebreak within 1s on the lexically greater **`version`** (was `sync_id`, not on the wire). The buggy in-handler resolver and the divergent funkygibbon resolver are off the sync path.
- **Tombstone deletes (§8)** — delete is now a new immutable version with `content.deleted=true` (parent = prior version), not a hard delete, so deletions converge through sync. All applies insert new version rows and are idempotent on `(id, version)`.

## Client (blowing-off)

- Persists the response **`server_time`** as its watermark (UTC-aware), not `datetime.now()`.
- **Applies deletes** (was "Skip deletes for now") — stores the tombstone version like any change.
- Conflict resolution is **server-authoritative** (server sends the winner; client applies it).
- `updated_at` for server changes derived from the version timestamp.

## Tests (all synchronous)

- `funkygibbon/tests/test_sync_protocol.py` — version units, canonical resolver tiebreak, and endpoint tests over an isolated NullPool DB (server_time present, delta exclusivity, fast-forward, concurrent-conflict version tiebreak, tombstone propagation, idempotent re-send).
- `blowing-off/tests/unit/test_sync_client_protocol.py` — updated_at-from-version, tombstone→delete, server_time parsing.
- Updated old assertions that encoded the doubled-Z format and `sync_id` tiebreak.

**funkygibbon + inbetweenies: 215 passed; blowing-off non-CLI unit: 107 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)