### PR TITLE
feat(blowing-off): stdio MCP server mirroring KittenKong

### DIFF
--- a/blowing-off/blowingoff/mcp/__init__.py
+++ b/blowing-off/blowingoff/mcp/__init__.py
@@ -1,7 +1,9 @@
 """
-MCP (Model Context Protocol) client for Blowing-Off.
+MCP (Model Context Protocol) for Blowing-Off.
 
-This module provides MCP functionality using local graph operations.
+Provides a local MCP client (LocalMCPClient) over local graph operations, and a
+stdio MCP *server* (blowingoff.mcp.server) that exposes the 12 knowledge-graph
+tools to MCP clients — mirroring the TypeScript KittenKong MCP server.
 """
 
 from .client import LocalMCPClient

--- a/blowing-off/blowingoff/mcp/server.py
+++ b/blowing-off/blowingoff/mcp/server.py
@@ -1,0 +1,252 @@
+"""
+Blowing-Off MCP Server
+
+A stdio MCP server that exposes the home knowledge-graph tools backed by the
+Blowing-Off local cache. It mirrors the TypeScript port's KittenKong MCP server
+(rolandcanyon-cmd/the-goodies-typescript): on startup it connects to a
+FunkyGibbon server, syncs the graph into the local database, keeps it fresh with
+background sync, and serves the same 12 tools to any MCP client (e.g. Claude
+Desktop / Claude Code).
+
+Run as:
+    python -m blowingoff.mcp.server
+
+Configuration (environment):
+    FUNKYGIBBON_URL            server URL (default http://localhost:8000)
+    FUNKYGIBBON_AUTH_TOKEN     bearer token (preferred; from `funkygibbon setup-auth`)
+    FUNKYGIBBON_PASSWORD       admin password (used if no token; default "admin")
+    SYNC_INTERVAL_SECONDS      background sync interval (default 60)
+    BLOWINGOFF_DB              local cache db path (default blowingoff.db)
+
+Example Claude Code mcpServers entry:
+    "blowingoff": {
+      "command": "python",
+      "args": ["-m", "blowingoff.mcp.server"],
+      "env": {"FUNKYGIBBON_URL": "http://localhost:8000",
+              "FUNKYGIBBON_AUTH_TOKEN": "<token>"}
+    }
+"""
+
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import mcp.types as types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from ..client import BlowingOffClient
+
+_ENTITY_TYPES = ("home, room, device, zone, door, window, procedure, manual, "
+                 "note, schedule, automation")
+
+# The 12 knowledge-graph tools, matching the KittenKong MCP server surface.
+TOOLS: List[types.Tool] = [
+    types.Tool(
+        name="search_entities",
+        description="Search for entities in the home knowledge graph by name or content",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query string"},
+                "entity_types": {"type": "array", "items": {"type": "string"},
+                                 "description": f"Optional filter by type: {_ENTITY_TYPES}"},
+                "limit": {"type": "number", "description": "Max results (default 10)"},
+            },
+            "required": ["query"],
+        },
+    ),
+    types.Tool(
+        name="get_entity_details",
+        description="Get full details for a specific entity by ID, including all relationships",
+        inputSchema={
+            "type": "object",
+            "properties": {"entity_id": {"type": "string", "description": "Entity ID"}},
+            "required": ["entity_id"],
+        },
+    ),
+    types.Tool(
+        name="create_entity",
+        description="Create a new entity in the knowledge graph",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity_type": {"type": "string", "description": f"Type: {_ENTITY_TYPES}"},
+                "name": {"type": "string", "description": "Entity name"},
+                "content": {"type": "object", "description": "Entity properties (arbitrary JSON)"},
+                "user_id": {"type": "string", "description": "User ID (optional, defaults to mcp-user)"},
+            },
+            "required": ["entity_type", "name", "content"],
+        },
+    ),
+    types.Tool(
+        name="update_entity",
+        description="Update an existing entity — creates a new immutable version",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Entity ID to update"},
+                "changes": {"type": "object", "description": "Fields to update in content"},
+                "user_id": {"type": "string", "description": "User ID (optional)"},
+            },
+            "required": ["entity_id", "changes"],
+        },
+    ),
+    types.Tool(
+        name="create_relationship",
+        description="Create a directed relationship between two entities",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "from_entity_id": {"type": "string", "description": "Source entity ID"},
+                "to_entity_id": {"type": "string", "description": "Target entity ID"},
+                "relationship_type": {"type": "string",
+                                      "description": "e.g. located_in, controls, documented_by, connected_to"},
+                "properties": {"type": "object", "description": "Optional relationship properties"},
+                "user_id": {"type": "string", "description": "User ID (optional)"},
+            },
+            "required": ["from_entity_id", "to_entity_id", "relationship_type"],
+        },
+    ),
+    types.Tool(
+        name="get_devices_in_room",
+        description="Get all devices located in a specific room",
+        inputSchema={
+            "type": "object",
+            "properties": {"room_id": {"type": "string", "description": "Room entity ID"}},
+            "required": ["room_id"],
+        },
+    ),
+    types.Tool(
+        name="find_device_controls",
+        description="Get available controls, automations, and procedures for a device",
+        inputSchema={
+            "type": "object",
+            "properties": {"device_id": {"type": "string", "description": "Device entity ID"}},
+            "required": ["device_id"],
+        },
+    ),
+    types.Tool(
+        name="get_room_connections",
+        description="Find doors, windows, and passages connecting a room to adjacent spaces",
+        inputSchema={
+            "type": "object",
+            "properties": {"room_id": {"type": "string", "description": "Room entity ID"}},
+            "required": ["room_id"],
+        },
+    ),
+    types.Tool(
+        name="find_path",
+        description="Find the relationship path between two entities in the graph",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "from_entity_id": {"type": "string", "description": "Starting entity ID"},
+                "to_entity_id": {"type": "string", "description": "Target entity ID"},
+                "max_depth": {"type": "number", "description": "Maximum path depth (default 5)"},
+            },
+            "required": ["from_entity_id", "to_entity_id"],
+        },
+    ),
+    types.Tool(
+        name="find_similar_entities",
+        description="Find entities similar to a given entity based on type and content",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "entity_id": {"type": "string", "description": "Reference entity ID"},
+                "threshold": {"type": "number", "description": "Similarity threshold 0–1 (default 0.5)"},
+                "limit": {"type": "number", "description": "Max results (default 10)"},
+            },
+            "required": ["entity_id"],
+        },
+    ),
+    types.Tool(
+        name="get_procedures_for_device",
+        description="Get all procedures, manuals, and instructions for a device",
+        inputSchema={
+            "type": "object",
+            "properties": {"device_id": {"type": "string", "description": "Device entity ID"}},
+            "required": ["device_id"],
+        },
+    ),
+    types.Tool(
+        name="get_automations_in_room",
+        description="Get all automation rules and schedules associated with a room",
+        inputSchema={
+            "type": "object",
+            "properties": {"room_id": {"type": "string", "description": "Room entity ID"}},
+            "required": ["room_id"],
+        },
+    ),
+]
+
+
+def result_payload(result: Any) -> Any:
+    """Reduce a client.execute_mcp_tool result to the payload to return: the
+    tool's ``result`` on success, an ``{"error": ...}`` object otherwise."""
+    if isinstance(result, dict) and result.get("success"):
+        return result.get("result")
+    if isinstance(result, dict):
+        return {"error": result.get("error", "tool failed")}
+    return result
+
+
+def build_server(client: BlowingOffClient) -> Server:
+    """Build the MCP Server wired to a (connected) Blowing-Off client."""
+    server = Server("blowingoff", "0.2.0")
+
+    @server.list_tools()
+    async def list_tools() -> List[types.Tool]:
+        return TOOLS
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: Optional[Dict[str, Any]]) -> List[types.TextContent]:
+        result = await client.execute_mcp_tool(name, **(arguments or {}))
+        payload = result_payload(result)
+        return [types.TextContent(type="text", text=json.dumps(payload, indent=2, default=str))]
+
+    return server
+
+
+async def serve() -> None:
+    server_url = os.environ.get("FUNKYGIBBON_URL", "http://localhost:8000")
+    token = os.environ.get("FUNKYGIBBON_AUTH_TOKEN") or None
+    password = os.environ.get("FUNKYGIBBON_PASSWORD", "admin")
+    interval = int(os.environ.get("SYNC_INTERVAL_SECONDS", "60"))
+    db_path = os.environ.get("BLOWINGOFF_DB", "blowingoff.db")
+
+    client = BlowingOffClient(db_path)
+    # Prefer a bearer token (from `funkygibbon setup-auth`); fall back to password.
+    await client.connect(
+        server_url,
+        auth_token=token,
+        password=None if token else password,
+        client_id="blowingoff-mcp-server",
+    )
+    # Initial sync, then keep the local cache fresh in the background.
+    try:
+        await client.sync()
+    except Exception as exc:  # don't fail startup if the first sync hiccups
+        print(f"blowingoff MCP server: initial sync warning: {exc}", file=sys.stderr)
+    await client.start_background_sync(interval)
+
+    server = build_server(client)
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, server.create_initialization_options())
+
+
+def main() -> None:
+    try:
+        asyncio.run(serve())
+    except KeyboardInterrupt:
+        pass
+    except Exception as exc:
+        print(f"blowingoff MCP server fatal error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/blowing-off/requirements.txt
+++ b/blowing-off/requirements.txt
@@ -7,6 +7,7 @@ aiohttp>=3.8.0
 rich>=10.0.0
 click>=8.3.3
 tabulate>=0.9.0
+mcp>=1.0.0
 pytest>=7.0.0
 pytest-asyncio>=1.4.0
 pytest-cov>=7.1.0

--- a/blowing-off/setup.py
+++ b/blowing-off/setup.py
@@ -72,10 +72,12 @@ setup(
         "rich>=10.0.0",
         "click>=8.0.0",
         "tabulate>=0.9.0",
+        "mcp>=1.0.0",
     ],
     entry_points={
         "console_scripts": [
             "blowing-off=blowingoff.cli.main:cli",
+            "blowingoff-mcp=blowingoff.mcp.server:main",
         ],
     },
     python_requires=">=3.11",

--- a/blowing-off/tests/conftest.py
+++ b/blowing-off/tests/conftest.py
@@ -26,9 +26,12 @@ def pytest_configure(config):
         "markers", "unit: marks tests as unit tests"
     )
 
-# Add FunkyGibbon to path
-funkygibbon_path = Path(__file__).parent.parent.parent / "funkygibbon"
-sys.path.insert(0, str(funkygibbon_path))
+# Put the repo ROOT on the path so `funkygibbon` / `inbetweenies` import as
+# packages. Inserting the funkygibbon dir itself would expose funkygibbon/mcp as
+# a top-level `mcp` and shadow the installed MCP SDK (mcp.server, mcp.types).
+repo_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(repo_root))
+funkygibbon_path = repo_root / "funkygibbon"  # used by the server fixture below
 
 
 @pytest.fixture(scope="session")

--- a/blowing-off/tests/unit/test_mcp_server.py
+++ b/blowing-off/tests/unit/test_mcp_server.py
@@ -1,0 +1,78 @@
+"""Synchronous unit tests for the Blowing-Off MCP server.
+
+These don't need a live FunkyGibbon server: they check the exposed tool surface
+matches the KittenKong reference, the schemas are well-formed, and the
+result-formatting maps client results to the right MCP payload.
+"""
+
+import asyncio
+
+from blowingoff.mcp.server import TOOLS, result_payload, build_server
+
+# The 12 knowledge-graph tools the KittenKong MCP server exposes.
+EXPECTED_TOOLS = {
+    "search_entities", "get_entity_details", "create_entity", "update_entity",
+    "create_relationship", "get_devices_in_room", "find_device_controls",
+    "get_room_connections", "find_path", "find_similar_entities",
+    "get_procedures_for_device", "get_automations_in_room",
+}
+
+
+def test_tool_surface_matches_kittenkong():
+    names = {t.name for t in TOOLS}
+    assert names == EXPECTED_TOOLS
+    assert len(TOOLS) == 12
+
+
+def test_every_tool_has_a_valid_object_schema_with_required():
+    for tool in TOOLS:
+        schema = tool.inputSchema
+        assert schema["type"] == "object"
+        assert "properties" in schema and isinstance(schema["properties"], dict)
+        assert isinstance(schema.get("required", []), list)
+        # Every required field is actually described in properties.
+        for field in schema.get("required", []):
+            assert field in schema["properties"], f"{tool.name}: {field} missing from properties"
+        assert tool.description
+
+
+def test_result_payload_success_returns_result():
+    assert result_payload({"success": True, "result": {"x": 1}}) == {"x": 1}
+
+
+def test_result_payload_failure_returns_error_object():
+    assert result_payload({"success": False, "error": "boom"}) == {"error": "boom"}
+    # Missing error string still yields an error object.
+    assert "error" in result_payload({"success": False})
+
+
+class _FakeClient:
+    """Stand-in for BlowingOffClient that records calls and returns canned results."""
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    async def execute_mcp_tool(self, name, **kwargs):
+        self.calls.append((name, kwargs))
+        return self._result
+
+
+def test_build_server_dispatches_calls_to_the_client():
+    client = _FakeClient({"success": True, "result": {"ok": True}})
+    server = build_server(client)
+    assert server.name == "blowingoff"
+
+    # The call-tool handler is registered; invoke it through the SDK's registry.
+    from mcp.types import CallToolRequest
+    handler = server.request_handlers[CallToolRequest]
+    req = CallToolRequest(
+        method="tools/call",
+        params={"name": "search_entities", "arguments": {"query": "lamp"}},
+    )
+    result = asyncio.run(handler(req))
+
+    assert client.calls == [("search_entities", {"query": "lamp"})]
+    # The text content carries the tool's result payload.
+    blocks = result.root.content
+    assert blocks[0].type == "text"
+    assert '"ok": true' in blocks[0].text


### PR DESCRIPTION
Extends the Python **blowing-off** client to also act as an **MCP server**, matching the TypeScript port's KittenKong MCP server (`rolandcanyon-cmd/the-goodies-typescript` → `packages/kittenkong/src/mcp-server.ts`): a stdio server exposing the same 12 knowledge-graph tools, backed by the local cache that syncs from FunkyGibbon.

## What

- **`blowingoff/mcp/server.py`** — `python -m blowingoff.mcp.server` (also a `blowingoff-mcp` console script). On startup it connects to FunkyGibbon (bearer token via `FUNKYGIBBON_AUTH_TOKEN`, else `FUNKYGIBBON_PASSWORD`), does an initial sync, starts background sync (`SYNC_INTERVAL_SECONDS`), and serves over stdio via the MCP SDK. Tool calls dispatch to the existing `BlowingOffClient.execute_mcp_tool`; results come back as JSON text.
- **The 12 tools match KittenKong exactly** — `search_entities`, `get_entity_details`, `create_entity`, `update_entity`, `create_relationship`, `get_devices_in_room`, `find_device_controls`, `get_room_connections`, `find_path`, `find_similar_entities`, `get_procedures_for_device`, `get_automations_in_room`.
- Declared the `mcp` dependency (requirements + setup.py) and added the `blowingoff-mcp` entry point.

## Drive-by fix

`blowing-off/tests/conftest.py` was inserting the **funkygibbon dir** onto `sys.path`, which exposed `funkygibbon/mcp` as a top-level `mcp` and **shadowed the installed MCP SDK**. Now it inserts the repo root so `funkygibbon`/`inbetweenies` import as packages.

## Example Claude Code config

```json
"blowingoff": {
  "command": "python", "args": ["-m", "blowingoff.mcp.server"],
  "env": {"FUNKYGIBBON_URL": "http://localhost:8000", "FUNKYGIBBON_AUTH_TOKEN": "<token from setup-auth>"}
}
```

## Tests (synchronous)

`blowing-off/tests/unit/test_mcp_server.py` — tool surface matches the 12-tool reference, schemas well-formed, result formatting (success/error), and call dispatch routes through the SDK handler to the client. **blowing-off non-CLI unit tests: 112 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)