### PR TITLE
docs: mark the Swift port (WildThing) abandoned; KittenKong is the live port

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Goodies is a modern smart home knowledge graph data store layer built around
 
 **Current Status**: ✅ **Production Ready** - All tests passing (225/225), comprehensive MCP functionality, full client-server synchronization, and enterprise-grade security features.
 
-**Related Projects**: adrianco/consciousness is an early prototype of the backend server that will be rewritten from scratch later. adrianco/c11s-house-ios is a native Swift iOS app that is the front end for the system. This repo is the knowledge graph protocol that will interface the app to the backend, and includes a command line client in Python that acts as a prototype implementation for the next phase, adrianco/the-goodies-swift, which will be integrated with adrianco/c11s-house-ios.
+**Related Projects**: adrianco/consciousness is an early prototype of the backend server that will be rewritten from scratch later. adrianco/c11s-house-ios is a native Swift iOS app that is the front end for the system. This repo is the knowledge graph protocol that interfaces the app to the backend, and includes the **Blowing-Off** Python client (a reference implementation, and now also an MCP server). The maintained port of the client is **KittenKong** (TypeScript, rolandcanyon-cmd/the-goodies-typescript). An earlier Swift port (adrianco/the-goodies-swift / *WildThing*) is untested and has been abandoned.
 
 ## 🏗️ Architecture
 

--- a/architecture/specifications/WILDTHING_ARCHITECTURE.md
+++ b/architecture/specifications/WILDTHING_ARCHITECTURE.md
@@ -1,5 +1,12 @@
 # WildThing Swift Package - Detailed Architecture Specification
 
+> **⚠ ABANDONED (2026-06-15).** The WildThing Swift port was never tested and is
+> no longer maintained. The live, maintained ports of the client are
+> **Blowing-Off** (Python, this repo — now also an MCP server) and **KittenKong**
+> (TypeScript, `rolandcanyon-cmd/the-goodies-typescript`). This document is kept
+> for historical reference only; it is not a conformance reference for the
+> `inbetweenies-v2` protocol (see `inbetweenies/PROTOCOL.md`).
+
 ## Overview
 
 WildThing is a Swift Package that provides a local-first MCP server for smart home knowledge graph operations. It's designed to run on iOS, macOS, watchOS, and tvOS devices, offering offline-capable home automation data management with optional cloud synchronization.

--- a/inbetweenies/PROTOCOL.md
+++ b/inbetweenies/PROTOCOL.md
@@ -1,8 +1,11 @@
 # Inbetweenies v2 — Sync Protocol Specification
 
 > **Status:** this is the authoritative spec for the `inbetweenies-v2` sync
-> protocol used between the **FunkyGibbon** server and clients (**Blowing-Off**
-> Python, the Swift and TypeScript ports). It is written from the real code, and
+> protocol used between the **FunkyGibbon** server and clients. The maintained
+> clients are **Blowing-Off** (Python, this repo) and **KittenKong** (the
+> TypeScript port, `rolandcanyon-cmd/the-goodies-typescript`) — KittenKong is the
+> reference port. (An earlier Swift port, *WildThing*, is untested and
+> abandoned; do not treat it as a conformance reference.) It is written from the real code, and
 > supersedes `inbetweenies/README.md`, which describes an **obsolete** model
 > (Home/Room/Accessory/Service/Characteristic). The real model is a generic
 > **Entity / Relationship knowledge graph**.


### PR DESCRIPTION
Documentation scrub for the abandoned Swift port (no Swift code exists in this Python repo). README, PROTOCOL.md, and the WildThing architecture spec now state that **KittenKong** (TypeScript) is the maintained/reference port and **Blowing-Off** (Python, now also an MCP server) is the other live client; the Swift port (`the-goodies-swift` / WildThing) is untested and abandoned (not a conformance reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)