### PR TITLE
ops(upgrade): default to macOS launchd agent; mint client token from existing secret

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,40 +26,71 @@ identical code.
 
 ## One command
 
-```bash
-# First-time auth with a real admin password (recommended):
-scripts/upgrade.sh --tag vX.Y.Z \
-  --admin-password 'choose-a-strong-password' \
-  --stop-cmd  "launchctl unload ~/Library/LaunchAgents/funkygibbon.plist" \
-  --start-cmd "launchctl load   ~/Library/LaunchAgents/funkygibbon.plist"
+The server runs as the standard macOS launchd LaunchAgent (`com.funkygibbon`),
+so the script stops/starts it for you — you normally pass only `--tag`:
 
-# …or trusted local/dev use with explicit test mode instead:
-scripts/upgrade.sh --tag vX.Y.Z --test-mode --test-password 'admin' \
-  --stop-cmd "…" --start-cmd "…"
+```bash
+scripts/upgrade.sh --tag vX.Y.Z --dry-run     # preview, change nothing
+scripts/upgrade.sh --tag vX.Y.Z               # do it
 ```
 
-Add `--dry-run` first to see exactly what it will do without changing anything.
-If you omit `--stop-cmd`/`--start-cmd` the script pauses and asks you to stop and
-start the service yourself at the right moments.
+If this install configures auth for the first time (rather than via the launchd
+start script), add one of:
+
+```bash
+  --admin-password 'choose-a-strong-password'   # a real admin password
+  --test-mode --test-password 'admin'           # explicit local/dev test mode
+```
+
+Override the service control only for a non-standard setup:
+
+```bash
+  --launchd-label com.something          # different LaunchAgent label
+  --launchd-plist /path/to/agent.plist   # explicit plist path
+  --stop-cmd "…" --start-cmd "…"         # non-launchd
+```
+
+The standard agent is loaded from `~/Library/LaunchAgents/com.funkygibbon.plist`
+(created by the house-agent bootstrap, `RunAtLoad`+`KeepAlive`). The script
+**unloads** it before migrating so KeepAlive doesn't respawn the old server
+mid-upgrade, then **loads** it to bring the new one back.
 
 ## What the script does (in order)
 
 1. **Pre-flight** — verifies a clean tree and that the tag exists.
-2. **Stop** the server.
+2. **Stop** the server — `launchctl unload` the LaunchAgent (so KeepAlive won't
+   respawn the old server while the database is migrated).
 3. **Back up** the database file (plus `-wal`/`-shm`) to
    `…/funkygibbon.db.backup-upgrade-<timestamp>`.
 4. **Checkout** the release tag.
 5. **Install** dependencies from `funkygibbon/requirements.txt`.
 6. **Migrate** data — `python -m funkygibbon.migrate --apply` (idempotent; safe
    to re-run; verifies counts before committing).
-7. **Set up auth** — `python -m funkygibbon.setup_auth …` generates/persists a
-   `JWT_SECRET`, sets the admin credential (or test mode), mints a long-lived
-   client token, and writes `~/.oook/config.json` and `./.blowingoff.json`.
-8. **Start** the server.
+7. **Set up auth** — only if you passed `--admin-password`/`--test-mode`:
+   `python -m funkygibbon.setup_auth …` generates/persists a `JWT_SECRET`, sets
+   the admin credential (or test mode), mints a long-lived client token, and
+   writes `~/.oook/config.json` and `./.blowingoff.json`. Skipped by default.
+8. **Start** the server — `launchctl load` the LaunchAgent.
 9. **Verify** — unauthenticated `/api/v1/graph/statistics` returns 401/403 and
    `/health` returns 200.
 
 Every step is idempotent; re-running the whole script is safe.
+
+> **Note for installs configured by the house-agent bootstrap:** auth is set in
+> the launchd start script's environment (`start_funkygibbon.sh` exports
+> `JWT_SECRET` and `ADMIN_PASSWORD_HASH`), not in `.env`. Leave the auth flags
+> off — the server keeps its existing credentials. Local clients then need a
+> bearer token signed with **that** `JWT_SECRET`. Pass `--mint-client-token` to
+> the upgrade (it reads the secret from `start_funkygibbon.sh` and writes the
+> client configs), or do it directly:
+>
+> ```bash
+> JWT=$(grep -m1 JWT_SECRET= start_funkygibbon.sh | cut -d'"' -f2)
+> python -m funkygibbon.setup_auth --client-token-only --jwt-secret "$JWT"
+> ```
+>
+> This mints a token against the existing secret and writes `~/.oook/config.json`
+> + `./.blowingoff.json` without changing any server auth config.
 
 ## Doing it by hand (fallback)
 

--- a/funkygibbon/setup_auth.py
+++ b/funkygibbon/setup_auth.py
@@ -128,6 +128,14 @@ def build_parser() -> argparse.ArgumentParser:
                       help="Set a real admin password (argon2-hashed into .env).")
     mode.add_argument("--test-mode", action="store_true",
                       help="Enable explicit, opt-in test mode (a known test password).")
+    mode.add_argument("--client-token-only", action="store_true",
+                      help="Mint a client token from an EXISTING JWT secret and write "
+                           "client configs, without changing any auth config. Use when "
+                           "the server's secret lives outside .env (e.g. a launchd start "
+                           "script): pass --jwt-secret or set JWT_SECRET.")
+    p.add_argument("--jwt-secret", metavar="SECRET",
+                   help="Existing JWT signing secret to mint the client token against "
+                        "(with --client-token-only). Falls back to $JWT_SECRET / .env.")
     p.add_argument("--test-password", metavar="PASS", default="admin",
                    help="Password accepted in test mode (default: admin).")
     p.add_argument("--server-url", default="http://localhost:8000",
@@ -158,11 +166,40 @@ def run(argv: Optional[list] = None) -> int:
     current = read_env(env_path)
     pm = PasswordManager()
 
+    insecure = {"", "development-secret-key", "dev-secret-key-change-in-production"}
+
+    # client-token-only: mint a token from an existing secret, touch no auth config.
+    if args.client_token_only:
+        secret = (args.jwt_secret or os.getenv("JWT_SECRET")
+                  or current.get("JWT_SECRET", "")).strip()
+        if secret in insecure:
+            print("error: no usable JWT secret — pass --jwt-secret or set JWT_SECRET "
+                  "to the secret the server actually signs with.", file=sys.stderr)
+            return 1
+        token = TokenManager(secret_key=secret).create_token(
+            user_id="local-client", role="admin",
+            permissions=["read", "write", "delete", "configure"],
+            expires_delta=timedelta(days=args.token_days),
+        )
+        print("FunkyGibbon client-token setup")
+        print(f"  client token: minted ({args.token_days}d) against the existing secret")
+        if args.print_token:
+            print(f"  TOKEN: {token}")
+        if not args.no_client_config:
+            print("client configs:")
+            write_json_config(Path(args.oook_config),
+                              {"server_url": args.server_url, "auth_token": token},
+                              args.dry_run)
+            write_json_config(Path(args.blowingoff_config),
+                              {"server_url": args.server_url, "auth_token": token,
+                               "client_id": "local", "db_path": "blowingoff.db"},
+                              args.dry_run)
+        return 0
+
     updates: Dict[str, str] = {}
 
     # 1. JWT secret -------------------------------------------------------- #
     secret = current.get("JWT_SECRET", "").strip()
-    insecure = {"", "development-secret-key", "dev-secret-key-change-in-production"}
     if args.rotate_secret or secret in insecure:
         secret = secrets.token_urlsafe(48)
         updates["JWT_SECRET"] = secret

--- a/funkygibbon/tests/test_setup_auth.py
+++ b/funkygibbon/tests/test_setup_auth.py
@@ -74,3 +74,31 @@ def test_dry_run_writes_nothing(tmp_path):
     env = tmp_path / ".env"
     setup_auth.run(["--env-file", str(env), "--no-client-config", "--test-mode", "--dry-run"])
     assert not env.exists()
+
+
+def test_client_token_only_mints_from_existing_secret_without_touching_env(tmp_path):
+    import json
+    env = tmp_path / ".env"
+    env.write_text("JWT_SECRET=server-secret-xyz\nADMIN_PASSWORD_HASH=$argon2id$abc\n")
+    before = env.read_text()
+    oook, bo = tmp_path / "oook.json", tmp_path / ".bo.json"
+
+    rc = setup_auth.run([
+        "--client-token-only", "--jwt-secret", "server-secret-xyz",
+        "--env-file", str(env), "--oook-config", str(oook), "--blowingoff-config", str(bo),
+    ])
+    assert rc == 0
+    assert env.read_text() == before  # auth config untouched
+
+    token = json.loads(oook.read_text())["auth_token"]
+    assert json.loads(bo.read_text())["auth_token"] == token
+    payload = TokenManager(secret_key="server-secret-xyz").verify_token(token)
+    assert payload and payload["role"] == "admin"
+
+
+def test_client_token_only_rejects_missing_or_insecure_secret(tmp_path, monkeypatch):
+    monkeypatch.delenv("JWT_SECRET", raising=False)  # not from the ambient env
+    env = tmp_path / ".env"  # no JWT_SECRET
+    rc = setup_auth.run(["--client-token-only", "--env-file", str(env),
+                         "--no-client-config"])
+    assert rc == 1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -22,9 +22,18 @@
 #   --test-password PASS   Test-mode password (default: admin).
 #   (omit both to leave existing auth config untouched)
 #
-# Service control (how to stop/start the server; omit to be prompted):
-#   --stop-cmd  "CMD"      e.g. "launchctl unload ~/Library/LaunchAgents/funkygibbon.plist"
-#   --start-cmd "CMD"      e.g. "launchctl load   ~/Library/LaunchAgents/funkygibbon.plist"
+# Service control (the server runs as a macOS launchd LaunchAgent; defaults to
+# the standard agent, so usually nothing to pass):
+#   --launchd-label LABEL  LaunchAgent label (default: com.funkygibbon).
+#   --launchd-plist PATH   Plist path (default: ~/Library/LaunchAgents/<label>.plist).
+#   --stop-cmd  "CMD"      Override the stop command (e.g. for a non-launchd setup).
+#   --start-cmd "CMD"      Override the start command.
+#
+# Client token (for installs whose JWT secret is in the launchd start script):
+#   --mint-client-token   Mint a client token from the server's existing secret
+#                         and write oook / blowing-off configs (no auth changes).
+#   --start-script PATH   Where to read JWT_SECRET from (default <repo>/start_funkygibbon.sh).
+#   --jwt-secret SECRET   Provide the secret directly instead of reading the script.
 #
 # Other:
 #   --db PATH              Database file (default: from settings / ./funkygibbon.db).
@@ -43,7 +52,12 @@ ADMIN_PASSWORD=""
 TEST_PASSWORD="admin"
 STOP_CMD=""
 START_CMD=""
+LAUNCHD_LABEL="com.funkygibbon"   # the standard macOS LaunchAgent for the server
+LAUNCHD_PLIST=""                   # default: ~/Library/LaunchAgents/<label>.plist
 SERVER_URL="http://localhost:8000"
+MINT_CLIENT_TOKEN=0
+START_SCRIPT=""        # default: <repo>/start_funkygibbon.sh
+JWT_SECRET_OVERRIDE=""
 SKIP_BACKUP=0
 DRY_RUN=0
 ASSUME_YES=0
@@ -63,7 +77,12 @@ while [ $# -gt 0 ]; do
     --test-password) TEST_PASSWORD="$2"; shift 2;;
     --stop-cmd) STOP_CMD="$2"; shift 2;;
     --start-cmd) START_CMD="$2"; shift 2;;
+    --launchd-label) LAUNCHD_LABEL="$2"; shift 2;;
+    --launchd-plist) LAUNCHD_PLIST="$2"; shift 2;;
     --server-url) SERVER_URL="$2"; shift 2;;
+    --mint-client-token) MINT_CLIENT_TOKEN=1; shift 1;;
+    --start-script) START_SCRIPT="$2"; shift 2;;
+    --jwt-secret) JWT_SECRET_OVERRIDE="$2"; shift 2;;
     --skip-backup) SKIP_BACKUP=1; shift 1;;
     --dry-run) DRY_RUN=1; shift 1;;
     --yes) ASSUME_YES=1; shift 1;;
@@ -73,14 +92,23 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$TAG" ] || die "--tag is required (the release tag to upgrade to)"
+
+# The server is always a macOS launchd service. Default to stopping/starting the
+# standard LaunchAgent (com.funkygibbon, RunAtLoad+KeepAlive) so the common case
+# needs no --stop-cmd/--start-cmd. Unload before migrating so KeepAlive doesn't
+# respawn the old server mid-upgrade; load to bring the new one back.
+[ -n "$LAUNCHD_PLIST" ] || LAUNCHD_PLIST="${HOME}/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+[ -n "$STOP_CMD" ]  || STOP_CMD="launchctl unload '$LAUNCHD_PLIST' 2>/dev/null || true"
+[ -n "$START_CMD" ] || START_CMD="launchctl load '$LAUNCHD_PLIST'"
 cd "$REPO_DIR"
 git rev-parse --git-dir >/dev/null 2>&1 || die "not a git repository: $REPO_DIR"
 
 log "Upgrade plan for $REPO_DIR"
 echo "   release tag:   $TAG"
 echo "   auth setup:    ${AUTH_MODE:-(leave existing untouched)}"
-echo "   service stop:  ${STOP_CMD:-(manual / prompt)}"
-echo "   service start: ${START_CMD:-(manual / prompt)}"
+echo "   launchd agent: $LAUNCHD_PLIST"
+echo "   service stop:  $STOP_CMD"
+echo "   service start: $START_CMD"
 echo "   backup DB:     $([ "$SKIP_BACKUP" = 1 ] && echo no || echo yes)"
 echo "   dry-run:       $([ "$DRY_RUN" = 1 ] && echo yes || echo no)"
 
@@ -155,6 +183,25 @@ if [ -n "$AUTH_MODE" ]; then
   fi
 else
   warn "no auth mode chosen; leaving existing auth config untouched"
+fi
+
+# 6b. Mint a client token from the server's existing secret ----------------- #
+# For installs whose JWT secret lives in the launchd start script (not .env),
+# give the local clients (oook / blowing-off) a token signed with that secret.
+if [ "$MINT_CLIENT_TOKEN" = 1 ]; then
+  log "Minting client token from the server's existing JWT secret"
+  secret="$JWT_SECRET_OVERRIDE"
+  if [ -z "$secret" ]; then
+    [ -n "$START_SCRIPT" ] || START_SCRIPT="$REPO_DIR/start_funkygibbon.sh"
+    if [ -f "$START_SCRIPT" ]; then
+      secret="$(grep -m1 'JWT_SECRET=' "$START_SCRIPT" | sed -E 's/.*JWT_SECRET=["'\'']?([^"'\'' ]+).*/\1/')"
+    fi
+  fi
+  if [ -z "$secret" ]; then
+    warn "could not find a JWT secret (pass --jwt-secret or --start-script); skipping token mint"
+  else
+    run "$PYTHON -m funkygibbon.setup_auth --client-token-only --jwt-secret '$secret' --server-url '$SERVER_URL'"
+  fi
 fi
 
 # 7. Restart the service ---------------------------------------------------- #


### PR DESCRIPTION
The server always runs as the standard macOS launchd LaunchAgent, so the upgrade should drive it directly instead of asking for stop/start commands.

## Changes
- **`upgrade.sh` defaults to the `com.funkygibbon` LaunchAgent** — `launchctl unload`/`load` of `~/Library/LaunchAgents/com.funkygibbon.plist`, matching the house-agent bootstrap (RunAtLoad+KeepAlive). Unloads before migrating so KeepAlive doesn't respawn the old server mid-upgrade. Overridable via `--launchd-label`/`--launchd-plist` (or `--stop-cmd`/`--start-cmd` for non-launchd). **You now usually pass only `--tag`.**
- **Client tokens for start-script-auth installs.** These installs set auth via the launchd start script's env (`start_funkygibbon.sh` exports `JWT_SECRET` + `ADMIN_PASSWORD_HASH`), not `.env`. So:
  - `setup_auth` gains **`--client-token-only`** (+ `--jwt-secret`): mints a client token against an *existing* secret and writes the oook / blowing-off configs **without** changing any auth config.
  - `upgrade.sh` gains **`--mint-client-token`**: reads `JWT_SECRET` from `start_funkygibbon.sh` and mints the token, so local clients keep working once auth enforcement is live. (Extraction verified against the real start script.)
- `UPGRADE.md` updated accordingly.

## Tests
2 new `setup_auth` tests (mints from an existing secret without touching `.env`; rejects a missing/insecure secret). **funkygibbon suite: 179 passed.**

Follows up the v0.2.0 upgrade tooling; will be in v0.2.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)