### PR TITLE
fix(models): defensive type checks for datetime and enum serialization

### DIFF
--- a/inbetweenies/models/entity.py
+++ b/inbetweenies/models/entity.py
@@ -112,8 +112,8 @@ class Entity(Base, InbetweeniesTimestampMixin):
             "source_type": source_type_value,
             "user_id": self.user_id,
             "parent_versions": self.parent_versions,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None
+            "created_at": self.created_at.isoformat() if hasattr(self.created_at, "isoformat") else self.created_at,
+            "updated_at": self.updated_at.isoformat() if hasattr(self.updated_at, "isoformat") else self.updated_at
         }
 
     @classmethod

--- a/inbetweenies/models/relationship.py
+++ b/inbetweenies/models/relationship.py
@@ -103,11 +103,11 @@ class EntityRelationship(Base, InbetweeniesTimestampMixin):
             "from_entity_version": self.from_entity_version,
             "to_entity_id": self.to_entity_id,
             "to_entity_version": self.to_entity_version,
-            "relationship_type": self.relationship_type.value,
+            "relationship_type": getattr(self.relationship_type, "value", self.relationship_type),
             "properties": self.properties,
             "user_id": self.user_id,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None
+            "created_at": self.created_at.isoformat() if hasattr(self.created_at, "isoformat") else self.created_at,
+            "updated_at": self.updated_at.isoformat() if hasattr(self.updated_at, "isoformat") else self.updated_at
         }
 
     def is_valid_for_entities(self, from_entity: "Entity", to_entity: "Entity") -> bool:


### PR DESCRIPTION
## Summary

`to_dict()` on `Entity` and `EntityRelationship` assumed `created_at`/`updated_at` are always `datetime` objects and that `relationship_type` is always an enum member. When a value arrives already serialized — a string timestamp, or a plain-string relationship type — the current code raises `AttributeError` instead of round-tripping the value.

This swaps the unconditional attribute access for a capability check, so an already-serialized value passes through unchanged and a real `datetime`/enum still serializes exactly as before.

## Changes

- `inbetweenies/models/entity.py` — `created_at`/`updated_at` use `hasattr(..., "isoformat")` instead of a truthiness check
- `inbetweenies/models/relationship.py` — same for both timestamps, plus `getattr(self.relationship_type, "value", self.relationship_type)`

## Notes

Behaviour is unchanged for the normal path (`datetime` in → ISO string out; enum in → `.value` out). The only difference is that a pre-serialized value no longer raises.

One thing worth a maintainer's eye: this is defensive rather than a root-cause fix. It makes serialization total, but if string timestamps are reaching `to_dict()` in practice there may be an upstream path that should be handing over `datetime` objects instead — I haven't traced where that originates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCn4S4yjKMFF3FyczcddGY