### PR TITLE
docs: design review at v0.3.0 + ADR-001..012 (review only — no implementation)

### DIFF
--- a/docs/adr/ADR-001-primary-datastore.md
+++ b/docs/adr/ADR-001-primary-datastore.md
@@ -1,0 +1,33 @@
+# ADR-001: Primary datastore — SQLite stays; explicit exit criteria for Postgres
+
+**Status:** Proposed · 2026-08-01
+
+## Context
+
+Entities live in SQLite (WAL) as immutable `(id, version)` rows. Live scale: 423 entities / 510 version rows / 5.7 MB. Honest worst-case for the larger use cases: ~20k entities, ~150k edges, ~365k version rows over years — 3–5 orders of magnitude below any engine's limits. Deployment is one server process per home on a Mac mini via launchd; backup is file copy (already built and running). Two installs, both controlled; migration is cheap *whenever* a reason exists.
+
+Measured bottlenecks are in the access layer (full-history scans reduced in Python — see ADR-002), not the engine.
+
+## Decision
+
+1. **SQLite remains the system of record** for structured data (entities, relationships, sync metadata).
+2. **No engine-specific SQL outside the repository layer** — everything through SQLAlchemy async, so the engine remains swappable by config + data copy.
+3. **Postgres is adopted if and when one of these triggers occurs**, and not before:
+   - a second writer *process* per install (beyond one FastAPI app),
+   - multi-tenant hosting (many homes, one database),
+   - hot server-side JSON content queries needing JSONB+GIN,
+   - replication requirements beyond file-level backup/mirror.
+4. **Neo4j is rejected** as primary store: the graph ops in use (BFS, k-hop, type/name lookup) run in microseconds in memory at this scale; a JVM service, a second wire protocol, and loss of single-file backup buy nothing. The in-memory index is the right design (its invalidation bug is ADR-003).
+5. **A dedicated vector database (ruvector or otherwise) is rejected as a store**; the similarity *feature* is ADR-006 (sqlite-vec in-file). Note: evaluated as a category — no product-specific assessment of ruvector was made.
+
+## Consequences
+
+- Zero migration work now; deployment/backup story unchanged.
+- ADR-002 is mandatory — staying on SQLite is only viable with the access layer fixed.
+- Revisit at each trigger, not on a calendar.
+
+## Alternatives considered
+
+- **Postgres now** — buys concurrency and JSONB nobody uses yet; costs a service to run on both installs and complicates the "database is one file you can copy" operational story that backup/mirror already exploits.
+- **Neo4j** — wrong workload class; average degree 2.2, no declarative multi-hop queries anywhere in the API.
+- **Vector store as primary** — a knowledge graph is not an embedding index; would still need a relational/graph store beside it.

--- a/docs/adr/ADR-002-data-access-layer.md
+++ b/docs/adr/ADR-002-data-access-layer.md
@@ -1,0 +1,27 @@
+# ADR-002: Latest-version and delta queries move into SQL
+
+**Status:** Proposed · 2026-08-01 · **This is the scalability unlock; ADR-001 depends on it.**
+
+## Context
+
+`funkygibbon/api/sync.py::_latest_entities()` executes `select(Entity)` — every version of every entity — and reduces to latest-per-id in Python. It is called once per sync request for the outgoing pull **and once per pushed change** inside `_apply_incoming()`. A 50-change push over 365k version rows materializes ~18M ORM rows. Delta filtering (`updated_at > since`) and entity-type filters also run in Python after the full scan. The only secondary index on `entities` is `entity_type`. The wire protocol has a `cursor` field; the server never populates it — responses are unbounded.
+
+## Decision
+
+1. **Latest-version semantics in SQL.** Either a window-function view (`row_number() over (partition by id order by version desc) = 1`) or — simpler and index-friendly — an `is_latest` boolean maintained transactionally on version insert (set false on the previous latest in the same transaction). Index `(is_latest, updated_at)` and `(id, version desc)`.
+2. **A server-assigned monotonic watermark.** Add `server_seq` (integer, autoincrement per row insert) and use it — not wall-clock `updated_at` — as the delta-sync cursor. Clock-independent, gap-free ordering; `since` becomes "seq > N", immune to same-timestamp edge cases the current exclusive-bound comparison has.
+3. **Batch the push path.** `_apply_incoming` resolves the latest row for the *specific* id being applied (`where id = :id and is_latest`), not the whole table; the per-batch set of ids is fetched once.
+4. **Paginate pull.** Populate `cursor` (last `server_seq` sent) with a page cap (e.g. 500 changes); clients loop until drained. The field already exists on the wire — KittenKong and blowing-off need only handle a non-null value.
+5. **Repository discipline:** these queries live in `GraphRepository`/sync repository only; no raw SQL leaks into routers (keeps ADR-001's engine exit clean).
+
+## Consequences
+
+- Sync cost becomes O(changes + page) instead of O(total history × changes).
+- One schema migration (new column + backfill + indexes) — trivial at 510 rows, and both installs are controlled.
+- `server_seq` becomes the natural foundation for ADR-005's protocol v3 cursor.
+- The GraphIndex load (ADR-003) also stops scanning dead versions: it loads `is_latest` rows only.
+
+## Alternatives considered
+
+- **Keep Python-side reduction, add caching** — caches inherit the invalidation problem ADR-003 exists to fix; the database is the right place for "latest".
+- **Move to Postgres for the optimizer** — the same view/index work is required there too; engine change doesn't remove the need.

--- a/docs/adr/ADR-003-graphindex-lifecycle.md
+++ b/docs/adr/ADR-003-graphindex-lifecycle.md
@@ -1,0 +1,31 @@
+# ADR-003: GraphIndex gets an owner, an invalidation rule, and a concurrency posture
+
+**Status:** Proposed · 2026-08-01 · **Correctness fix — highest-priority code change in this review.**
+
+## Context
+
+`routers/graph.py` holds `_graph_index` as a module global, built lazily on first request, never rebuilt. Three defects:
+
+- **Sync writes never touch it.** Once a second client syncs changes in, every graph/MCP read on the server serves pre-sync state until process restart. This defeats the system's core promise.
+- **REST writes patch it partially.** `create_entity` calls `_add_entity()` but not `_build_nodes()`: the entity is findable by name yet invisible to `find_path`/`get_connected_entities`. Relationship creation has the mirror problem.
+- **Multi-worker divergence.** Under `uvicorn --workers N`, N independent copies drift apart. (Today's deployment is 1 worker — by luck, not by contract.)
+
+## Decision
+
+1. **Single owner.** The index becomes an app-lifecycle object (FastAPI `lifespan` state), not a router-module global. Routers receive it via dependency; nothing else may construct one.
+2. **Write-through, fully.** Every mutation path — REST create/update/delete, **sync apply**, blob attach — goes through repository methods that update storage and index in the same code path. `_add_entity`/`_add_relationship` maintain `nodes` incrementally (the incremental update is O(1); `_build_nodes()`'s full rebuild becomes load-time-only).
+3. **Generation-tagged rebuild as the safety net.** The index carries the `server_seq` (ADR-002) it was built at; a cheap `max(server_seq)` check on read detects missed writes and triggers rebuild-on-drift (log loudly — drift means a write path bypassed rule 2).
+4. **Concurrency posture made explicit: one worker process.** Documented and asserted at startup (refuse `workers > 1` unless the index is disabled). This is honest about the design rather than pretending the global is safe. If multi-worker ever matters, the options are a shared cache or per-worker indexes keyed on generation — a new ADR then.
+5. **Deleted entities excluded** at load and on write-through (ties into ADR-004 tombstones).
+
+## Consequences
+
+- Graph reads become correct under sync — the prerequisite for trusting a second client or a mobile app.
+- Load cost drops with ADR-002 (latest-rows-only scan).
+- The 1-worker constraint is now a stated invariant instead of an accident.
+
+## Alternatives considered
+
+- **Rebuild per request** — correct but wasteful; at 20k entities a rebuild is tens of ms, too slow for every MCP call.
+- **TTL cache** — bounded staleness is still staleness; invalidation is cheap here because all writes already funnel through repositories.
+- **Drop the index, query SQL each time** — recursive CTEs for BFS in SQLite are possible but slower and far less readable than 150k edges in RAM; wrong trade.

--- a/docs/adr/ADR-004-version-retention-and-tombstones.md
+++ b/docs/adr/ADR-004-version-retention-and-tombstones.md
@@ -1,0 +1,73 @@
+# ADR-004: Temporal model — as-of queries, interval edges, bitemporal-lite
+
+**Status:** Proposed (v2 — rewritten 2026-08-01 after the as-of-query requirement landed; supersedes the "graph is current" draft)
+
+## Context
+
+New first-class use case: *pick a point in the past and query/reason about the state of the house at that point.* This overturns two calls from the v1 draft of this ADR:
+
+- v1 proposed dropping edge/version pinning because "nothing exposes time-travel traversal" — as-of queries are exactly that consumer.
+- v1 proposed pruning old version rows — pruning destroys as-of fidelity inside the pruned window.
+
+What exists today, measured against the requirement:
+
+- **Entities are already time-travelable.** Immutable `(id, version)` rows; the version string's timestamp prefix is lexically ordered = chronological. "Version of E at time T" is a max-version-≤-T lookup that works *now*.
+- **Edges are not — the data is being destroyed.** `entity_relationships` rows have no end and no history: when a device moves rooms, the old `located_in` edge is replaced and the prior topology is unrecoverable. The composite version-pin (`from_entity_version`/`to_entity_version`) does not help: it freezes where an edge pointed *at creation*, and says nothing about when it stopped being true. It is the half-measure the review flagged (C4) — temporal-looking, temporally useless.
+- **Two timelines already exist implicitly** and must not be conflated: the version-string timestamp is *valid time* (when the edit happened, per the editing client — an offline phone edit at 14:00 synced at 18:00 carries 14:00), while server apply order (`server_seq`, ADR-002) is *transaction time* (when the server learned it). Any as-of design that picks only one silently mis-answers one class of question.
+
+## Decision
+
+### 1. Edges become immutable interval rows
+
+Replace in-place edge mutation/deletion with the same discipline entities already have:
+
+- Each relationship row gains `valid_from` (set at creation) and `valid_to` (nullable; null = still true).
+- Changing an edge (re-point, property change) = **end the old row** (`valid_to = now`) **and insert a new row**. Deleting = end the row. Rows are never updated in content and never deleted.
+- Edge "current at T" ⇔ `valid_from ≤ T < coalesce(valid_to, ∞)`. Current graph = `valid_to IS NULL` (indexed; the GraphIndex loads exactly this set — ADR-003 unchanged).
+- **The composite version-pin columns are dropped** (with their FKs). Edges reference entity *ids*; the *time axis*, not a frozen pin, resolves versions — see §3. (`from/to_entity_version` may be retained as provenance metadata during migration, but nothing joins on them.)
+
+### 2. Two timelines, one job each: client time is the query axis; server time is the replication axis
+
+- Every entity version row and edge row carries **valid time** (client edit time — already in the version string; **materialized as an indexed column and preserved verbatim by the server**) and **transaction time** (`server_seq` / server apply timestamp — arriving with ADR-002).
+- **The as-of axis is valid time.** Editing and querying are primarily client-side (ADR-009 v2); "state at T" therefore means *when edits were made*, which is the question the house-history use case asks. The server stores client time untouched — clamped for LWW ordering (ADR-005) but never rewritten.
+- **Transaction time is used only for replication**: the sync cursor, pagination, and audit. Queries never consult `server_seq`; sync never consults client time.
+- **Retroactivity, stated honestly:** an as-of answer may *improve* when a late-syncing client's edits arrive — the record of 14:00 gets better at 18:00 when the offline phone syncs. This is the correct behavior for history, and it is documented rather than hidden. Once all clients have synced, every replica computes identical snapshots (verified by the ADR-011 digest).
+- **Clock-sanity guard:** the ADR-005 clamp stops future-stamped edits; a symmetric guard flags (never silently rewrites) suspiciously *old* valid times — an edit claiming to be older than its client's last sync watermark minus a grace window is applied but reported, so a device with a broken clock can't quietly rewrite deep history.
+
+### 3. As-of resolution rule (the "resolve cleanly" contract)
+
+`snapshot(T)` is defined over the **accepted lineage** on the valid-time axis:
+
+1. **Accepted lineage:** conflict-resolution losers (stored per ADR-011 but recorded as losers in the resolution audit) are *excluded from every snapshot* — they are recoverable archive, not state. This keeps as-of well-defined even though losers sit in history with their own timestamps, and it keeps every replica's answer identical after sync: the rule depends only on synced state plus the shared resolution outcome, never on local perspective.
+2. **Entities:** for each id, the accepted version row with the greatest valid time ≤ T; excluded if a tombstone (`deleted_at ≤ T`, structural per §4) is current at T.
+3. **Edges:** accepted rows with `valid_from ≤ T < coalesce(valid_to, ∞)` (valid-time axis).
+4. **Resolution:** each surviving edge's endpoints resolve to the entity versions chosen in step 2 — *by id + T*, never by pin. An edge whose endpoint has no surviving version at T (entity not yet created / already deleted) is excluded and counted as an integrity warning — with interval edges and structural tombstones this should be impossible; surfacing it beats hiding it.
+
+Exposure: an `at` parameter on **every** graph read — REST, MCP tools, and client-local queries alike — with omitted meaning now (the uniform query interface, ADR-009 v2 §2). Server implementation: SQL snapshot + a transient in-memory index built at T (milliseconds at this scale — the persistent GraphIndex remains now-only, as the cache of the `at = now` case). A `diff(T1, T2)` endpoint falls out nearly free and is the tool an agent wants for "what changed since yesterday?".
+
+### 4. Tombstones (unchanged from v1)
+
+`deleted_at` becomes a structural column on the terminating version row; sync carries `change_type: "delete"` as today. Tombstones are what make step 1's exclusion and step 3's integrity guarantee work.
+
+### 5. Retention: keep everything (v1's pruning is withdrawn)
+
+As-of fidelity is now a feature; pruned history is a hole in it. Version volume at this design point (infrequent updates, blobs excluded from versioning) is small — the original immutable-forever posture is affordable and now earns its keep. The ADR-007 tripwire (warn at 500 MB) is the review trigger; if it ever fires, pruning returns as an *explicit horizon* ("as-of supported back to date X"), never a silent default.
+
+### 6. Sync protocol impact (rides ADR-005/011 machinery)
+
+Edge interval rows sync as immutable rows exactly like entity versions: idempotent on row id, end-events (`valid_to` set) travel as ordinary changes, per-id acks apply. Concurrent edge edits (two clients re-point the same edge) resolve through the ADR-005 ladder — both end the same predecessor row; the ladder picks which successor is "current", and the loser's row stays in history, satisfying ADR-011's no-silent-loss invariant for topology as well as content.
+
+## Consequences
+
+- "State of the house at T" becomes a defined, tested query — on the *transaction* axis, reproducible forever.
+- Storage grows with edit history, deliberately; measured against the tripwire rather than pruned on faith.
+- One real migration: add interval columns (backfill `valid_from` from `created_at`, `valid_to` null), drop the pinned-version FKs, and change the edge write path from update-in-place to end+insert. Both installs controlled; the edge count is 461.
+- Clients replicate the temporal schema and answer as-of locally with the same resolution rule (ADR-009 v2) — every query takes `at`, omitted = now, so "current" is nowhere a special case.
+- The conformance suite (ADR-010) gains snapshot invariants: `snapshot(T)` is internally consistent (no dangling edges), stable under replay, and `diff(T1,T2) ∘ snapshot(T1) = snapshot(T2)`.
+
+## Alternatives considered
+
+- **Keep version-pinned edges as the temporal mechanism** — pins say where an edge pointed at creation, not when it ceased; they cannot answer as-of without interval ends anyway, and they force relationship rewrites on every entity version bump. Worst of both worlds; this is the C4 defect, not a design.
+- **Full bitemporal (valid-time intervals editable retroactively, audit of the audit)** — the textbook machinery (Snodgrass) is built for correcting recorded history; nothing in the use case edits the past, it only *queries* it. Bitemporal-lite records both instants and skips the four-column interval algebra.
+- **Event sourcing / rebuild-from-log** — the version rows *are* the event log in materialized form; a separate log adds a second source of truth to keep consistent for no added query power at this scale.
+- **Snapshot tables (periodic full copies)** — simple but lossy between snapshots and redundant beside immutable versions; rejected.

--- a/docs/adr/ADR-005-protocol-v3-clocks-and-conflicts.md
+++ b/docs/adr/ADR-005-protocol-v3-clocks-and-conflicts.md
@@ -1,0 +1,39 @@
+# ADR-005: Inbetweenies v3 — server-arbitrated resolution ladder; clamped LWW; no HLC
+
+**Status:** Proposed (v2 — rewritten 2026-08-01 after design discussion; supersedes the earlier HLC draft) 
+
+## Context
+
+Design point, agreed: a handful of clients, infrequent updates, server-authoritative sync — and the hard requirement is that concurrent writes can never corrupt or silently destroy data. The earlier draft of this ADR recommended hybrid logical clocks. That recommendation is **withdrawn**: HLC earns its complexity when multiple authorities order events, and this system has exactly one — every write serializes through the server's apply path. Given a single arbiter, the ordering rule only needs to be *deterministic* and *intuitive*; the robustness comes from what happens around the rule (ADR-011), not from the clock.
+
+What v2 already gets right and v3 preserves: server-authoritative apply; causality-aware fast-forward via the `parent_versions` DAG (`api/sync.py` correctly distinguishes fast-forward from concurrent edit, and treats a parentless overwrite as a conflict); idempotent `(id, version)` inserts; per-id acks.
+
+## Decision
+
+1. **Ordering rule: last-write-wins by client edit time, clamped by the server for ordering only.** The client's timestamp is **preserved verbatim in storage** (it is the valid-time query axis, ADR-004 §2 — the owner-set premise is that client time is the truth about when edits happened); the clamp to `server_now + ε` (ε ≈ 5 min) applies only inside the *resolution comparison*, so a skewed or lying clock can never win "from the future" — the only real LWW failure mode this topology has. A clamped-for-ordering edit keeps its claimed time in history but is flagged (ADR-004 §2 clock-sanity guard). Ties break on the version string (already unique via counter + writer id). "The later edit wins" matches human expectation for a smart-home knowledge graph.
+
+2. **Resolution ladder** (server-side, in order; deterministic at every rung):
+   1. **Fast-forward** — client edited from our latest → apply, no conflict (exists today).
+   2. **Per-entity-type rule** — deterministic rules **supplied by the domain manifest** (ADR-012; salvaged in spirit from the deleted `funkygibbon/sync/conflict_resolution.py`: union device capabilities, prefer-enabled automations — both now live in `domains/house`). Rules produce a merge version with both parents in the DAG.
+   3. **Three-way field merge** — find the common ancestor via `parent_versions` (the DAG is already stored; the deleted `VersionTree.find_common_ancestor` proved it's cheap). Keys changed on one side take that side; keys changed on both fall through to rung 4 *for that key set*. Three-way is deletion-safe: the base distinguishes "deleted" from "never existed" — the exact defect that made the dead 2-way merge resurrect deletions.
+   4. **Clamped LWW** on whatever remains.
+   5. **Loser preserved** — the losing version is stored as a non-latest version row, acked as processed, and reported (ADR-011). Optionally, entity types may be flagged `manual`: instead of rung 4, the conflict lands in a persisted review queue (salvaged from the dead code's in-memory `pending_manual_resolutions`; viable precisely because conflicts are rare at this design point).
+
+3. **Wire changes for v3** (modest; no clock migration): delta pagination via the `server_seq` cursor (ADR-002); **the delta stream carries every immutable row** — all entity versions and edge interval rows since the cursor, not a latest-per-id projection, so clients can replicate history (ADR-009 v2 §4); structural tombstones on the wire (ADR-004 §4); **edge interval rows** — relationship changes carry `valid_from`/`valid_to`, an edge end-event is an ordinary idempotent change, and the pinned `from/to_entity_version` fields leave the wire (ADR-004 §1/§6); a state-digest field for convergence verification (ADR-011 — computed over the full row set, which the replica model makes directly comparable); the dead `vector_clock` field **removed**. Version negotiation covers the transition; both installs are controlled, so the v2 window can be short.
+
+4. **PROTOCOL.md §7 is rewritten to specify the ladder** precisely enough that a client implementation needs no access to server code — it remains the contract a Swift/mobile client is built from. The conformance suite (ADR-010) asserts each rung.
+
+5. **HLC is explicitly deferred**, with its trigger written down: adopt it only if a second authority ever appears (multi-server, peer-to-peer, or client-to-client sync). None is on the roadmap.
+
+## Consequences
+
+- Concurrent edits to *different fields* of the same entity — the common real case — merge cleanly instead of one side losing wholesale.
+- Every client implements only: version strings, parent tracking, push-until-acked, and pull-apply. All resolution intelligence stays server-side — the cheapest possible contract for the mobile client.
+- Clock skew is defanged rather than solved; acceptable because the server is the only judge and losers are never destroyed (ADR-011).
+- Rung 2 and the manual queue are *optional strictness* — the ladder degrades gracefully to fast-forward + LWW if nobody writes type rules.
+
+## Alternatives considered
+
+- **HLC / vector clocks** — solve a multi-authority problem this topology doesn't have; cost lands on every future client implementation.
+- **CRDTs** — per-field JSON merge semantics would dominate client complexity for a domain where concurrent same-entity edits are rare and a human review queue is affordable.
+- **First-arrival-wins (pure `server_seq`)** — maximally simple and clock-free, but "whoever syncs first wins" surprises humans; clamped LWW is one clamp away and matches intuition.

--- a/docs/adr/ADR-006-search-fts-and-similarity.md
+++ b/docs/adr/ADR-006-search-fts-and-similarity.md
@@ -1,0 +1,26 @@
+# ADR-006: Text search via SQLite FTS5; similarity via sqlite-vec (optional, deferred-friendly)
+
+**Status:** Proposed · 2026-08-01
+
+## Context
+
+`search_entities` walks all entities in Python computing substring/word-overlap scores; `find_similar_entities` ranks by shared-word counts. Fine at 423 entities; linear and quality-poor at 20k with document-like content (manuals, notes). This is also where "should it be a vector database?" actually lands: the *feature* is similarity, the *store* doesn't need to change (ADR-001).
+
+## Decision
+
+1. **FTS5 virtual table** over `name` + flattened `content` text fields, maintained by triggers (or in the repository write path alongside ADR-003's write-through). BM25 ranking replaces the hand-rolled scorer for `search_entities`. Zero new dependencies — FTS5 ships in SQLite.
+2. **Similarity, when wanted, is `sqlite-vec` in the same database file:** an embeddings table keyed by entity id, refreshed on write for the entity types where semantic similarity matters (notes, manuals, procedures). Exact k-NN at ≤20k vectors is milliseconds; no ANN index tuning, no second service, single-file backup preserved.
+3. **Embedding generation is the only open dependency** (a local model or an API call). Until that's chosen, `find_similar_entities` falls back to FTS5 more-like-this (query by top terms of the source doc) — a real quality improvement over word overlap with no ML dependency at all. sqlite-vec lands only when embeddings have an owner.
+4. Search stays server-side (clients query via API/MCP as today); client-local search on mobile can reuse the same FTS5 design in its local store (ADR-009) later.
+
+## Consequences
+
+- Search quality and cost both improve; the Python scorer and its 16%-covered module retire.
+- No new deployment artifacts; ADR-001's single-file story holds.
+- A dedicated vector DB (ruvector et al.) remains unjustified at this corpus size; revisit only if embeddings outgrow memory-mapped exact search (≫10⁶ vectors — not a smart-home number).
+
+## Alternatives considered
+
+- **Dedicated vector database** — third artifact to run/back up/keep consistent on two Mac minis, for ≤60 MB of vectors. Category mismatch.
+- **Postgres + pgvector** — the right shape *if* ADR-001's exit ever triggers; not a reason to exit by itself.
+- **Embed in the API process with FAISS/numpy** — workable, but loses persistence-with-the-data and adds Python-only state a Swift server-less future would re-solve.

--- a/docs/adr/ADR-007-blob-storage.md
+++ b/docs/adr/ADR-007-blob-storage.md
@@ -1,0 +1,27 @@
+# ADR-007: Blobs move to content-addressed files; the database keeps metadata
+
+**Status:** WITHDRAWN · 2026-08-01 — owner decision: blobs stay in-row. Single-file consistent backup is valued above the externalization benefits, and current volume (1 blob, 5.7 MB database) doesn't threaten it. One residue adopted: a size tripwire — warn in logs/health when the database crosses 500 MB so the decision is revisited on evidence. The original proposal is preserved below for that future discussion; the schema already leaves the door open (`data` nullable, `server_url`, per-blob sync status).
+
+## Context
+
+`blobs.data` is `LargeBinary` in the SQLite row — photos and PDF manuals inline in the database file. Consequences compound: the DB file (and its WAL) grows with every scanned manual; every backup copy and iCloud mirror upload re-copies all binary history; a future full sync to mobile drags blobs through the JSON protocol (base64 inflation) or needs a side channel anyway. The model already anticipates externality: `data` is nullable with a `server_url` field ("can be null if not yet downloaded"), and sync tracks blob status separately — the design is half-externalized already.
+
+## Decision
+
+1. **Content-addressed blob store on disk:** `blobs/<sha256[0:2]>/<sha256>` beside the database. The `blobs` table keeps metadata (id, name, type, mime, size, checksum, sync status) and drops the `data` column; checksum *is* the storage key, giving free dedup and integrity verification.
+2. **Small-blob exception:** ≤ 64 KB (thumbnails, QR codes) may stay in-row — one file-copy backup unit is worth preserving for tiny payloads. A single code path decides by size at write.
+3. **HTTP transfer, not protocol payload:** blobs move over dedicated endpoints (`GET/PUT /blobs/{checksum}`, ranged), referenced from entity sync by checksum. The sync protocol carries metadata only — mobile clients fetch lazily, exactly what `BlobStatus.PENDING_UPLOAD`/`server_url` were reaching for.
+4. **Backup/mirror jobs add the blob directory** as a second rsync-style unit (cheap: content-addressing makes it append-only in practice).
+5. Migration: one script exports existing `data` blobs to files and rewrites rows (1 blob today; both installs controlled).
+
+## Consequences
+
+- Database size becomes a function of *structured* data only; ADR-004's retention math stays honest.
+- Backups stop re-copying binaries that didn't change; iCloud mirror gets cheaper.
+- Mobile sync payloads stay small; images arrive on demand with resumable ranged GETs.
+- The filesystem is now part of the data's integrity story — the backup job must treat DB + blob dir as one snapshot set (checksums make verification trivial).
+
+## Alternatives considered
+
+- **Stay in-row** — simplest, and SQLite handles BLOBs fine, but every operational cost above scales with binary volume, which is the one dimension a "scan all the manuals" use case grows without bound.
+- **Object storage (S3/R2)** — introduces a cloud dependency and credentials for a system whose value proposition includes local-first; `server_url` leaves the door open later without deciding now.

--- a/docs/adr/ADR-008-delete-dead-sync-stack.md
+++ b/docs/adr/ADR-008-delete-dead-sync-stack.md
@@ -1,0 +1,26 @@
+# ADR-008: Delete the dead sync stack (funkygibbon/sync/) — one sync implementation
+
+**Status:** Proposed · 2026-08-01 · **Lowest risk, highest clarity-per-line in the review.**
+
+## Context
+
+`funkygibbon/sync/` — `binary.py`, `conflict_resolution.py`, `delta.py`, `transfer.py`, `versioning.py`, 937 LOC of Merkle trees, `VersionTree`, and `DeltaSyncEngine` — has **zero production importers**. Only `funkygibbon/tests/test_sync.py` exercises it (and thereby inflates coverage). The real, live sync is `inbetweenies/sync/` (wire types + protocol) + `funkygibbon/api/sync.py` (server apply/ack logic, rewritten in v0.3.0).
+
+The cost is not the bytes. Graphify ranks `DeltaSyncEngine`, `MerkleNode`, `VersionTree`, and `ConflictResolver` among the repo's community hubs — a newcomer (or an LLM assistant) reading the graph or grepping "how does sync work" finds an elaborate machine that never runs, beside the modest one that does. During this review it cost real time to establish which stack was live; it will cost every future contributor the same.
+
+## Decision
+
+1. **Delete `funkygibbon/sync/` and its test file.** Git history preserves it; if a Merkle-based delta optimization is ever wanted, it will be redesigned against protocol v3 anyway, not resurrected.
+2. **Sweep the same class of debt in the same pass:** `blowing-off/blowingoff/sync/conflict_resolver.py`'s overlap with `inbetweenies/sync/conflict.py` (client should use the shared one), and any `archive/`-candidate modules Graphify shows with no inbound edges (a `graphify update .` after the deletion gives the verification for free).
+3. **The invariant, stated in CLAUDE.md:** sync logic lives in exactly two places — `inbetweenies/sync/` (shared contract) and `funkygibbon/api/sync.py` (server application). A third location is a review-blocking smell.
+
+## Consequences
+
+- ~1,000 LOC and several misleading graph hubs disappear; the honest coverage number drops slightly (the deleted tests tested deleted code — the number was lying upward).
+- "How does sync work" has one answer.
+- No runtime change whatsoever — verified by the zero-importer analysis; the full suite must pass unchanged after deletion as the merge gate.
+
+## Alternatives considered
+
+- **Move to `archive/`** — the repo already has an `archive/` for docs; code that doesn't compile against the living tree rots misleadingly there too. Git history *is* the archive for code.
+- **Finish the Merkle design instead** — delta-by-watermark (ADR-002/005) is O(changes) already; Merkle anti-entropy pays off for peer-to-peer or many-replica topologies, which contradicts the server-authoritative model the protocol just doubled down on.

--- a/docs/adr/ADR-009-client-cache-single-store.md
+++ b/docs/adr/ADR-009-client-cache-single-store.md
@@ -1,0 +1,59 @@
+# ADR-009: The client is a temporal replica — one query interface, time is always a parameter
+
+**Status:** Proposed (v2 — rewritten 2026-08-01; supersedes the latest-only cache draft after the client-side as-of requirement landed)
+
+## Context
+
+Owner-set design premises (2026-08-01 discussion): **editing and querying are primarily client-side, with sync to the server; clients hold their own copy of the entire database; the client's edit time is preserved by the server.** Plus the design rule that motivated v2: *every query carries a time, and supplying the current time yields the latest state.* v1's "client caches are latest-only; as-of is a server capability" contradicts all of it.
+
+The design point makes full replication the *simple* answer, not the heavy one: infrequent updates and blob-free versioning mean full history is small — 510 version rows today; years of edits are tens of thousands of rows, single-digit MB. A phone holds the whole timeline comfortably.
+
+The v1 problems all still stand and their fixes carry over: blowing-off's dual store (SQLAlchemy DB **plus** JSON files), pending marks in a separate file from the writes they mark, KittenKong's shared shape, and the pull-overwrite bug (ADR-011 C6, filed as the-goodies#69).
+
+## Decision
+
+### 1. One SQLite store, same shape as the server
+
+The client cache is a **replica of the server's temporal schema**: `entity_versions` (immutable rows, all versions), `relationships` (immutable interval rows per ADR-004), `pending_changes`, `sync_state` (cursor per server). The JSON `LocalGraphStorage` and the parallel SQLAlchemy store are deleted; `client_sync_tracking` merges into `sync_state`. Latest-only projection disappears — "latest" is a query, not a table. Under multi-domain (ADR-012), this design instantiates **once per domain**: one local database file per domain a client holds, synced against that domain's endpoint, with its own cursor and digest.
+
+### 2. The uniform query interface
+
+Every read — client and server, REST, MCP tool, and library call — takes `at: Timestamp` with **omitted/`null` meaning now**:
+
+- `snapshot(at)` resolves exactly as ADR-004 §3: entity versions by max-axis ≤ `at`, edges by interval cover, endpoints resolved by id + `at`.
+- Because the schemas match, **the resolution rule is implemented once per client platform against the same table shapes** — the Python, TS, and future Swift implementations are ports of one small algorithm (a two-predicate SQL query plus endpoint resolution), not three designs. It joins PROTOCOL.md as part of the reference client design.
+- `omitted = now` rather than the caller stamping wall-clock, so the common case has one canonical meaning and no client/server clock comparison. Passing an explicit time is choosing the time-travel path, deliberately.
+- **Pinned-snapshot reasoning:** a caller may take `t0 = current cursor position` and pass it to every query in a session, getting a *mutually consistent* view immune to syncs landing mid-session — the primitive an LLM agent reasoning over the house wants. This falls out of the design for free and gets documented as the recommended pattern for multi-query reasoning.
+
+### 3. The client's time axis, honestly defined
+
+The as-of axis is **valid time — client edit time** (ADR-004 §2), which the server preserves verbatim. A pending (unsynced) local edit therefore already has its place on the timeline: its own timestamp. The rule:
+
+- Every query — `at = now` or `at = past T` — resolves over **synced accepted rows plus this client's pending rows**, all by valid time. Read-your-writes holds at every point in time: your 14:00 edit is visible in a 14:30 as-of query whether or not it has synced yet.
+- A pending edit is *provisionally accepted*: if conflict resolution later demotes it (ADR-005 ladder), the local answer for that window changes — the same retroactivity that late-arriving remote edits already cause (ADR-004 §2), symmetric and documented.
+- **The convergence digest (ADR-011) is computed over synced state only** — pending rows are excluded, so two mid-sync replicas don't false-alarm; after sync, identical row sets ⇒ identical digests ⇒ identical snapshots.
+
+### 4. Sync carries history, not a latest-projection
+
+The v3 delta stream (ADR-005) ships **every immutable row** — all entity versions and edge interval rows/end-events since the cursor — not the server's latest-per-id reduction. Clients stop discarding superseded versions. Idempotent row-id application and per-id acks are unchanged; a fresh client's full sync is delta-from-zero (paginated) and equals the server's history minus blobs (blob `data` stays lazy per ADR-007's surviving fields).
+
+### 5. History horizon as the escape hatch, not the default
+
+If some future client genuinely can't hold full history, it may sync from a cursor floor (`server_seq ≥ X`). Its as-of answers before the horizon are refused offline ("history unavailable before ⟨date⟩") or proxied to the server when online — never silently wrong. No current client needs this; it exists so the protocol doesn't have to change when one does.
+
+### 6. Durability rules (carried from v1, unchanged)
+
+Pending marks are written in the **same transaction** as the local edit; ack processing clears them transactionally; **pull-apply never overwrites an entity with a pending local change** (the ADR-011 C6 guard — with the temporal schema this becomes natural: pulled rows *insert alongside* history rather than replacing state, and only the "what is latest" question ever contends).
+
+## Consequences
+
+- Client-side time travel works offline, and "current" is nowhere a special case — one code path, tested once per platform against the shared conformance suite (ADR-010), which gains the §3 axis rules as cases.
+- Client storage grows from "latest" to "everything" — single-digit MB at this design point, same 500 MB tripwire philosophy as the server, with §5 as the pressure valve.
+- The pull-overwrite bug class disappears *structurally*: immutable-row insertion has no overwrite to get wrong. (The C6 fix in the current latest-only clients is still needed now — ADR-011 sequencing unchanged.)
+- Migration per client: create the temporal schema, full-sync from zero, delete JSON files. Both Python clients trivial; KittenKong follows its issue #3 work.
+
+## Alternatives considered
+
+- **Latest-only cache + server-proxied as-of (v1)** — dies on the offline requirement; also leaves client and server running *different* query logic, which the uniform-interface rule exists to prevent.
+- **Materialized `latest` table beside history** — a denormalization to maintain under sync; at this row count, `max(version) ≤ at` with an index *is* fast enough, and one source of truth beats two.
+- **Sync latest + fetch history on demand** — reintroduces online-only as-of through the back door and a second wire shape; rejected.

--- a/docs/adr/ADR-010-tests-and-packaging.md
+++ b/docs/adr/ADR-010-tests-and-packaging.md
@@ -1,0 +1,39 @@
+# ADR-010: Test architecture and packaging — real-server standard, cover the shared core, one workspace
+
+**Status:** Proposed · 2026-08-01
+
+## Context
+
+508 tests pass in 36s at 70% coverage — healthy headline, uneven substance:
+
+- **The shared core is the least-tested code:** `inbetweenies/graph/traversal.py` 12%, `inbetweenies/mcp/tools.py` 15%, `graph/search.py` 16%, `graph/operations.py` 20%. This is exactly the code every client (including a future Swift one) depends on or ports.
+- **15 mock-based test files** (vs 23 on the excellent v0.3.0 real-server harness), including three overlapping auth suites (`TestAuthManager`, `TestAuthManagerSync`, `TestAuthManagerAsync`); several mostly assert mock wiring.
+- **Coverage lies upward** while ADR-008's dead code ships with its own tests.
+- **Packaging drift:** `python_requires` disagrees (≥3.8 / ≥3.9 / ≥3.11 across packages); legacy `setup.py` layouts already caused the 2a6284f incident (inbetweenies registering `mcp`/`models`/`sync` as top-level packages, shadowing the real MCP SDK machine-wide). Environment reconstruction for this review needed three attempts to discover the full dependency set.
+- The repo carries CI, but no coverage floor per package.
+
+## Decision
+
+**Tests**
+
+1. **The real-server harness is the default.** New integration tests use the root-conftest server fixture; mock-based tests are reserved for error-path unit tests where a real server can't produce the condition.
+2. **Protocol conformance suite** — a named test module asserting server behavior against PROTOCOL.md (acks, idempotency, ordering, pagination, tombstones, conflict records as v3 lands). This suite is the compatibility gate for *every* client implementation and the document Swift work trusts. Under ADR-012 it is **parameterized by domain manifest** and runs against each configured domain — the byte-identical-house gate for the abstraction step, and the proof the engine is genuinely domain-blind once garage exists.
+3. **Coverage floor on `inbetweenies/` of 80%**, enforced per-package in CI (`--cov=inbetweenies --cov-fail-under=80`); the overall number stops being the metric that matters.
+4. **Consolidate the three auth suites into one** parameterized suite; delete tests that only assert mocks were called.
+5. `graphify update .` runs in CI post-merge so the knowledge graph (and its dead-code signal) stays fresh.
+
+**Packaging**
+
+6. **One uv workspace** at the repo root: root `pyproject.toml` with workspace members `funkygibbon`, `inbetweenies`, `blowing-off`, `oook`, and the domain packages (`domains/house`, later `domains/garage` — ADR-012); `setup.py` files retired; **`requires-python = ">=3.11"` everywhere** (the deployed interpreter); one lockfile. `pip install -e .` from root produces the complete dev environment in one step.
+7. Version pins for cross-package deps expressed as workspace references so inbetweenies can't drift from its consumers.
+
+## Consequences
+
+- The code a mobile port depends on gains a tested contract; protocol changes get caught by the conformance suite instead of by Corfe.
+- Env setup becomes one command; the `find_packages()` class of accident is structurally gone.
+- Some coverage-number pain up front (deleting dead-code tests and mock tests lowers the headline before the floor raises it honestly).
+
+## Alternatives considered
+
+- **Poetry / plain pip-tools** — workable; uv's workspace model maps cleanest onto the four-package monorepo and is the current ecosystem default.
+- **Raise overall coverage floor to 80%** — invites padding tests in easy corners; the per-package floor on the shared core targets the actual risk.

--- a/docs/adr/ADR-011-sync-robustness-no-silent-loss.md
+++ b/docs/adr/ADR-011-sync-robustness-no-silent-loss.md
@@ -1,0 +1,33 @@
+# ADR-011: Sync robustness — no write is ever silently lost
+
+**Status:** Proposed · 2026-08-01 · Companion to ADR-005 (the ladder decides *who wins*; this ADR guarantees *nobody vanishes*). Carries the salvage from the deleted sync stack (ADR-008) and one live bug.
+
+## Context
+
+The design requirement is blunt: concurrent writes must not corrupt or silently destroy data. Three gaps in the live code violate it today, one of them client-side and actively dangerous:
+
+- **C6 (live bug, client): pull overwrites unpushed local edits.** The sync cycle pulls before it pushes, and `blowing-off/blowingoff/sync/engine.py::_apply_single_change` (line ~268) stores the server's entity over local storage with **no check for a pending local edit on the same id**. Sequence: edit entity X offline; another client edits X meanwhile; sync → pull applies the server's version over the local edit *before the push phase runs* → push reads storage (now the server's own version) and sends it back → idempotent ack clears the pending mark. The local edit is destroyed **without the server ever seeing it**; no conflict is recorded anywhere. KittenKong shares the pattern. Filed upstream (see issue link in PR/issue tracker).
+- **Losing writes are not stored.** `api/sync.py::_resolve_conflict` reports the loser once in a transient `ConflictInfo` and discards the data. The immutable version table makes preservation nearly free.
+- **Push batches are not atomic.** `_insert_version` commits per change; a crash mid-batch leaves a half-applied push — server-side partial state, the textbook corruption case.
+
+## Decision
+
+1. **Client pull-guard (fix first, independently of v3).** An entity with a pending local change is never overwritten by pull-apply. The pull records the incoming server version aside; the pending edit is pushed and the *server* adjudicates via the ADR-005 ladder; the client's state updates from the ack/conflict outcome. Applies to blowing-off and KittenKong; the rule joins ADR-009's reference client design ("a pending mark is a lock against pull-apply").
+2. **Losers become version rows.** A version that loses resolution is stored as a non-latest row (it is already parented into the DAG), **acked** (it was processed — ends the ambiguity between "lost" and "not received"), and reported in `conflicts` with winner/loser version ids. Any human can recover the losing content from history. Retention follows ADR-004.
+3. **Atomic push application.** One database transaction per push request: apply all changes, commit once, then compute acks. A crash yields "nothing applied, nothing acked, client retries" — never a partial batch.
+4. **Convergence digest** (salvaged, simplified, from the deleted Merkle code's `compute_sync_checksum`): server computes `sha256` over the sorted `(id, latest_version)` set — cheap at this scale, incrementally maintainable later — and returns it in every sync response; client computes the same over its cache and compares. Mismatch → client performs a full resync and reports loudly. Divergence becomes detectable instead of theoretical.
+5. **Persisted manual-review queue** (salvaged from the dead code's in-memory list): a `sync_conflicts` table holding queued conflicts for entity types flagged `manual` in the ADR-005 ladder, plus the resolution audit trail for automatic resolutions. Surfaced via an API endpoint; at this conflict rate the queue will almost always be empty, which is exactly why it's affordable.
+
+**Anti-decisions, recorded deliberately:** no 2-way content merge anywhere (it resurrects deletions — the deleted stack's cautionary defect); no merge versions authored as synthetic users (`"sync-merge"`) — merge versions carry the *winning writer's* user id plus a `merged: true` marker; no Merkle tree (single-server topology; the digest is the 20-line degenerate form that delivers the verification value).
+
+## Consequences
+
+- The five robustness properties become: single serialization point (exists) · causal fast-forward (exists) · idempotent acked application (exists) · **no silent loss** (2+1) · **verified convergence** (4). Together with the pull-guard (1), a concurrent write can lose *prominence* but never *existence*.
+- Client complexity rises by one rule (the pull-guard); everything else is server-side.
+- The digest adds one hash per sync — noise at this scale.
+
+## Alternatives considered
+
+- **Push-before-pull ordering** as the C6 fix — narrows the window but doesn't close it (a pull between edit and next sync still overwrites); the guard is the invariant, ordering is just hygiene.
+- **Rebase local edits onto pulled versions client-side** — re-parents the pending change for a cleaner fast-forward, but puts merge intelligence in every client; rejected for the same reason ADR-005 keeps resolution server-side.
+- **Trust the suite instead of a digest** — tests prove the algorithm; the digest proves *this pair of databases*. Different failure classes (bit-rot, missed invalidation, operator surgery).

--- a/docs/adr/ADR-012-domain-abstraction.md
+++ b/docs/adr/ADR-012-domain-abstraction.md
@@ -1,0 +1,83 @@
+# ADR-012: Domain abstraction — a generic temporal-graph engine, house and garage as domain packages
+
+**Status:** Proposed · 2026-08-01
+
+## Context
+
+Owner direction: the sync/auth/query engine should serve **unrelated domains**. First: the existing smart-home graph. Second: a **car collection** — what's in the garage, the history of each car, issues and service records. Topology decided up front: **shared auth/sync/query code · separate endpoint · separate database file · separate MCP client per domain.** Sequencing decided too: abstract first, get the new code working for house, then instantiate garage.
+
+How deep the house assumptions go today, measured:
+
+- **Schema-level:** `entity_type`, `relationship_type`, and `source_type` are `SQLEnum` columns — HOME/ROOM/DEVICE and located_in/controls are baked into the *database*, so a new domain is currently a schema migration. `EntityType` is imported by 45 files.
+- **Tool-level:** of the 12 MCP tools, **7 are already generic** (search/create/update entity, create relationship, find_path, entity details, find_similar) and **5 are house vocabulary** (`get_devices_in_room`, `find_device_controls`, `get_room_connections`, `get_procedures_for_device`, `get_automations_in_room`) — thin graph queries with 18 hardcoded type references.
+- **Engine-level: nothing.** Versioning, the temporal model (ADR-004), sync + resolution ladder (ADR-005/011), auth, blobs, graph index/traversal/search, backup — none of it mentions a house. The abstraction is overdue but shallow.
+
+The garage domain is also a validation case: "history of the cars and issues" is *exactly* the as-of machinery — a car's bay changes are interval edges, an issue's lifecycle is version history, `snapshot(T)` answers "what was in the garage in March".
+
+## Decision
+
+### 1. Type columns become strings; vocabulary moves to a domain manifest
+
+`entity_type`, `relationship_type`, `source_type` (and `blob_type`) become plain `String` columns. Validation moves to the API/sync boundary, checked against the **domain manifest** — the engine stores what the domain declares. This simultaneously removes the schema-per-domain problem and the enum-vs-string fragility that e2e4fe5 / PR #62 papered over (`getattr(x, "value", x)` dances disappear: the wire, the store, and the code all speak strings).
+
+### 2. A domain is a small package with a declared shape
+
+```
+domains/
+  house/    — the current vocabulary + 5 house tools + seed/import scripts
+  garage/   — CAR, BAY, SERVICE_RECORD, ISSUE, DOCUMENT, ... (phase 2)
+```
+
+A domain declares, via a typed manifest the engine consumes:
+
+- `entity_types`, `relationship_types` (each with allowed endpoint types — e.g. `located_in: CAR→BAY`), `source_types` — validated at write time.
+- `mcp_tools`: the domain's query tools. Most are **declarative**: name, description, params, and a generic graph query (type filter + relationship walk + `at` parameter) executed by the engine — `get_devices_in_room` and a future `get_cars_in_bay` are the *same* engine query with different constants. A tool may drop to a Python handler when it genuinely needs logic; the declarative form is preferred because it ports to every client for free.
+- `conflict_rules` (optional): the ADR-005 rung-2 registry, now explicitly *supplied by the domain* (union-capabilities and prefer-enabled move into `domains/house`).
+- Seed/import scripts (`populate_graph_db.py` becomes `domains/house/seed.py`).
+
+The engine's 7 generic tools ship with the engine and appear in every domain's MCP surface, `at`-parameterized per ADR-009.
+
+### 3. Deployment: one engine process, N mounted domains
+
+One FastAPI process (one launchd service, as today) hosts each configured domain as a sub-application:
+
+- **Routing:** `/{domain}/api/v1/...` and an MCP endpoint per domain (`/{domain}/mcp`) — *separate endpoint, separate MCP client* per the topology decision. Existing house paths stay canonical during transition via a redirect/alias.
+- **Storage:** one database file per domain (`house.db`, `garage.db`) — each keeps the single-file backup story (ADR-001/007); the backup/mirror jobs enumerate configured domains.
+- **Auth: shared.** One JWT secret, one admin/token system, tokens valid across domains on the instance (owner premise: same operator). A per-domain claim can be added later without a protocol change if a domain ever needs distinct audiences.
+- **Sync: the protocol is domain-blind.** Inbetweenies v3 messages gain exactly one field: `domain`. A client syncs each domain it holds against that domain's endpoint into that domain's local database file (ADR-009 replica per domain). Server-side, each domain has its own `server_seq` sequence and digest — domains never share a timeline.
+- Config lists the mounted domains; adding one is config + manifest, not engine code.
+
+### 4. Cross-domain references — links by value, never by join
+
+Owner refinement (2026-08-01): query isolation stands, but an entity in one domain may **reference** an entity in another — *"car parts for car X stored in house at location Y."* The mechanism keeps every isolation property:
+
+- **A reference is an ordinary interval edge that lives entirely in the referring domain**, whose remote endpoint is a qualified value: `(domain, entity_id)` plus an optional cached display label. The garage `stored_at` edge from the parts box to `house:⟨room-id⟩` is a garage row in `garage.db` — it syncs on garage's timeline, counts in garage's digest, and obeys garage's snapshot rule for its interval and its *local* endpoint. Nothing about it touches house's database, sequence, or digest.
+- **Exactly one endpoint may be external**, and the manifest declares where such edges may point: `stored_at: PART_BOX → external(house: ROOM | note)`. The edge always lives in the domain of its local endpoint.
+- **Dereference is an API/MCP-layer act, best-effort by design.** Server-side, both domains are mounted in one process, so resolving `house:⟨id⟩` at time T is a local read of the *other* database's `snapshot(T)`. Client-side, a client holding both replicas (the phone will) resolves locally the same way; a client holding only garage shows the cached label and the qualified id. Unreachable ≠ broken.
+- **No cascades, by construction.** Deleting the house room cannot reach into garage. The reference dangles — detected by a periodic integrity sweep that *reports* dangling or type-mismatched external refs (distinct from the intra-domain integrity warning in ADR-004 §3.4, which remains impossible-by-construction). Validation at write time is likewise **soft**: when the target domain is reachable the server checks existence and declared type and warns on mismatch, but never rejects — cross-domain write ordering is not guaranteed and must not deadlock a sync.
+- **Reverse lookup** ("what garage items are stored in this room?") is inherently a cross-domain question; it is offered — clearly above the isolation boundary — as an engine MCP tool, `find_references_to(domain, entity_id [, at])`, that scans the *locally mounted/held* domains' reference edges. It reads N local databases; it never crosses the network to a domain the caller doesn't hold.
+
+### 5. What explicitly does NOT change
+
+The temporal model, resolution ladder, ack contract, replica design, auth mechanics, blob handling, and the conformance suite are engine-level and untouched. The conformance suite (ADR-010) runs **per domain manifest** — the same invariants asserted against house and garage prove the abstraction is real rather than aspirational.
+
+### 6. Sequencing (owner-set)
+
+1. **Abstract:** strings-for-enums migration + manifest extraction + `domains/house` package; house behavior byte-identical (the conformance suite is the gate).
+2. **Prove:** land the v3/temporal work against house as planned (ADR sequence unchanged).
+3. **Instantiate:** `domains/garage` — manifest + seed + a handful of declarative tools (`get_cars_in_bay`, `get_car_history`, `get_open_issues`, `get_service_records`); second database file; second MCP client config.
+
+## Consequences
+
+- New domains become cheap and honest: vocabulary + tools + seeds, no engine changes, no schema migration.
+- The 5 house tools likely collapse into declarative definitions, deleting ~300 lines of `tools.py` and its 12–20%-covered hand-rolled query code (helps the ADR-010 coverage goal from the deletion side).
+- One process serving N domains concentrates blast radius (a crash takes both down) — accepted at this scale; the mount design leaves per-domain processes available by config if that ever changes.
+- Cross-domain **queries** remain out of scope — domains are isolated databases. Cross-domain **references** are supported per §4: links by value in the owning domain, best-effort dereference, soft validation, reported (never cascaded) dangling. The schema cost is two nullable columns on the relationship table (`external_domain`, cached label); domains that never reference outward pay nothing.
+- 45 files touching `EntityType` get a mechanical import change in step 1 — large diff, low risk, gated by the suite.
+
+## Alternatives considered
+
+- **Multi-tenant single database (domain column on every row)** — one file again couples backup/restore across domains, complicates per-domain sync sequences and digests, and buys nothing the mount design lacks; rejected against the owner topology (separate files was explicit).
+- **Fork the codebase per domain** — two copies of the engine to fix bugs in; the entire review's dead-code section is the cautionary tale.
+- **Fully generic vocabulary (no manifest, arbitrary strings)** — maximum flexibility, but typo-tolerant writes silently fragment the graph (`"DEVICE"` vs `"device"` vs `"Device"`); the manifest keeps writes honest while staying data, not schema.
+- **Keep enums, add garage members to them** — one shared vocabulary pollutes both domains and makes the *third* domain worse; rejected on arrival.

--- a/docs/design-review-2026-08.md
+++ b/docs/design-review-2026-08.md
@@ -1,0 +1,111 @@
+# The Goodies — Design & Implementation Review
+
+**Date:** 2026-08-01 (updated same day after design discussion) · **Reviewed at:** `d00749b` (v0.3.0)
+**Status: review only — no implementation yet.** All ADRs are *Proposed*; further review time is planned before any code changes.
+**Inputs:** Graphify knowledge graph (4,205 nodes · 6,782 edges · 211 communities over 221 files), full test run (508 passed, 70% coverage, 36s), live production instance (423 entities · 461 relationships · 510 version rows · 5.7 MB), and code reading guided by the graph's community hubs.
+
+This document has two parts: **findings** (what was measured — unchanged by opinion) and **decisions** (where the design discussion landed, recorded in ADR-001…012). Where a decision overturned the reviewer's first recommendation, that is said plainly.
+
+---
+
+## 1. Executive summary
+
+The architecture is fundamentally sound and recent work (v0.3.0 sync acks, the ephemeral-port test harness, auth-at-router-registration) moved it in the right direction. The four-package split — server / client / shared protocol / CLI — is the correct shape for multiple client implementations sharing one sync contract.
+
+**The database engine is not the problem.** The measured scalability ceiling is the *access layer* — full-history table scans reduced in Python, per sync request and per pushed change — not SQLite. Decision: **SQLite stays** (ADR-001), the access layer moves into SQL (ADR-002), and blobs **stay in-row** for single-file consistent backup (ADR-007 withdrawn, owner decision, with a 500 MB tripwire).
+
+The system is being extended around three owner-set premises that emerged in review:
+
+1. **Time is a first-class query dimension** — pick a point in the past and reason about the state of the house (ADR-004: interval edges, as-of snapshots). Every query takes `at`; omitted means now (ADR-009).
+2. **Clients are primary** — editing and querying happen mostly client-side; clients hold a full replica of each domain database; the client's edit time is preserved by the server and is the query axis (ADR-004/009).
+3. **The engine is domain-generic** — house today, a car-collection (garage) domain next, as isolated databases sharing auth/sync/query code, with cross-domain *references* by value but no cross-domain queries (ADR-012).
+
+The most serious code findings are unchanged and still ahead of any of that work: a client-side silent-data-loss bug (filed as **the-goodies#69**), a stale-forever graph cache, ~1,000 lines of dead sync machinery, and the shared core being the least-tested code in the repo.
+
+---
+
+## 2. Findings (measured)
+
+| Dimension | Value |
+|---|---|
+| Packages | funkygibbon 14.8k LOC · blowing-off 10.2k · inbetweenies 4.4k · oook 0.9k |
+| HTTP endpoints | 42 · MCP tools: 12 (7 generic, 5 house-specific) |
+| Tests | 508 passing, 36s wall, 70% line coverage |
+| Real-server integration tests | 23 files on the v0.3.0 ephemeral-port harness; 15 mock-based |
+| Live instance | 423 entities · 461 relationships · 510 version rows · 5.7 MB |
+| Graphify | 4,205 nodes · 6,782 edges · 211 communities; 96% deterministically extracted |
+| Installs | 2, both controlled — migration freedom is real |
+
+**F1 — Client pull destroys unpushed local edits (worst finding; live bug; filed as adrianco/the-goodies#69).** The sync cycle pulls before it pushes, and `_apply_single_change` (blowing-off `sync/engine.py:268`) overwrites local storage with no pending-edit guard. An offline edit can be replaced by a concurrent server change *before the push phase runs*; the push then sends the server's own version back, which is idempotently acked, clearing the pending mark. The edit is destroyed without the server ever seeing it and no conflict recorded. KittenKong shares the pattern.
+
+**F2 — `GraphIndex` staleness.** Module-global, built on first request, never invalidated. Sync-applied changes never touch it; REST `create_entity` patches it only partially (visible to name search, invisible to `find_path` until restart). Divergent copies under multi-worker.
+
+**F3 — Access-layer scans.** `_latest_entities()` = `select(Entity)` (every version of every entity) reduced in Python, called once per sync **plus once per pushed change**. Delta filtering also in Python. The `cursor` wire field exists but is never populated — responses unbounded. Only secondary index: `entity_type`.
+
+**F4 — Dead sync stack (937 LOC).** `funkygibbon/sync/{binary,conflict_resolution,delta,transfer,versioning}.py` — Merkle trees, `VersionTree`, `DeltaSyncEngine` — has zero production importers; only its own tests exercise it (inflating coverage). Graphify ranks its classes as community hubs of a system that never calls them.
+
+**F5 — Edges have no history, and version-pins don't help.** Relationships carry composite FKs to entity *versions* but no lifecycle (no end, no history): when a device moves rooms the prior topology is destroyed. The pin freezes where an edge pointed at creation — temporal-looking, temporally useless (and it can dangle against post-conflict-resolution latest versions).
+
+**F6 — Wall-clock conflict resolution; losers vanish.** LWW by version-string timestamp (clamp-free), with the losing version *not stored* — reported once in a transient `ConflictInfo`, then gone. A dead `vector_clock` field rides every message (`RESERVED — echoed, never read`). Push application commits per change (partial batch on crash).
+
+**F7 — Client dual store.** blowing-off keeps a SQLAlchemy SQLite DB *and* JSON graph files, with pending marks in a separate file from the writes they mark — no transactional truth.
+
+**F8 — The shared core is the least-tested code.** `inbetweenies/graph/traversal.py` 12%, `mcp/tools.py` 15%, `graph/search.py` 16%, `graph/operations.py` 20% — against 70% overall. Exactly the code every client depends on. Packaging drift alongside (`python_requires` ≥3.8/≥3.9/≥3.11; the 2a6284f `find_packages()` incident).
+
+**F9 — Domain coupling is shallow but schema-deep.** House vocabulary (`EntityType`, `RelationshipType`, `SourceType`) is baked in as `SQLEnum` **database columns** (45 importing files); 5 of 12 MCP tools are house-specific thin queries. The engine itself (sync, versioning, auth, graph, blobs) is already domain-blind.
+
+**What's right (keep):** protocol-as-package (inbetweenies); per-id acks (v0.3.0) — the correct durability contract; causality-aware fast-forward via `parent_versions` (better than the review initially credited); immutable lexically-ordered version strings; the ephemeral-port test harness with server-ownership proof; auth at router registration; Graphify in the loop (its hub list flagged F4 instantly).
+
+---
+
+## 3. Decisions (where the discussion landed)
+
+**D1 — SQLite stays; the access layer is the fix (ADR-001/002).** Honest worst-case sizing (~20k entities, ~150k edges, ~365k version rows) is orders of magnitude below engine limits. Latest-version semantics and delta move into SQL (`is_latest`, `(id, version)` index, `server_seq` watermark, pagination); repository discipline keeps a later Postgres exit a config change. Neo4j rejected (BFS over ≤150k in-memory edges; avg degree 2.2). Vector DB rejected as a store; similarity is a *feature* via FTS5 now and sqlite-vec if/when embeddings get an owner (ADR-006).
+
+**D2 — Blobs stay in-row (ADR-007 WITHDRAWN — owner decision, reversing the review's proposal).** Single-file consistent backup is valued above externalization; current volume is trivial. Residue: a 500 MB size tripwire so the question reopens on evidence.
+
+**D3 — Temporal model (ADR-004 v2).** Edges become immutable **interval rows** (`valid_from`/`valid_to`; change = end + insert); version-pin columns dropped. `snapshot(T)`: accepted-lineage versions by time, edges by interval cover, endpoints resolved **by id + T**. Retention: **keep everything** (the review's pruning proposal withdrawn — pruned history is a hole in as-of fidelity; volume makes forever affordable). Tombstones become structural (`deleted_at`).
+
+**D4 — Two timelines, one job each (ADR-004/005, owner-set).** **Client edit time is the query axis** — preserved verbatim by the server, clamped only inside conflict-resolution comparison. **Server time (`server_seq`) is the replication axis** — cursors, pagination, audit; queries never touch it. Consequence stated honestly: as-of answers can improve when late-syncing edits arrive; once synced, all replicas answer identically. Clock-sanity guards flag (never rewrite) suspicious timestamps.
+
+**D5 — No HLC (ADR-005 v2, reversing the review's first draft).** One authority (the server) means the ordering rule needs to be deterministic and intuitive, not distributed-systems-complete. Resolution ladder: **fast-forward → per-type rule (from the domain manifest) → 3-way merge via DAG common ancestor → clamped LWW → loser preserved**; optional per-type manual-review queue. HLC deferred with an explicit trigger (a second authority).
+
+**D6 — No silent loss (ADR-011).** The pull-guard (F1 fix — first change to make, independent of everything else); losers stored as version rows and acked; one transaction per push batch; a convergence digest over synced rows; a persisted conflict/review table. Salvage from the dead stack: per-type rules, manual queue, common-ancestor merge, state digest — as *ideas*; the code (with its deletion-resurrecting 2-way merge) is deleted per ADR-008.
+
+**D7 — Clients are full temporal replicas with a uniform query interface (ADR-009 v2, owner-set).** Every read takes `at` (omitted = now); client and server run the same `snapshot(at)` rule over the same schema; read-your-writes holds at every point in time (pending edits sit on the timeline at their own timestamps, provisionally accepted). Single SQLite store per domain per client; JSON dual-store deleted; pinned-snapshot (`t0`) reasoning documented as the pattern for multi-query consistency.
+
+**D8 — Domain abstraction (ADR-012, owner-set).** Type columns become strings validated against a per-domain **manifest** (types, relationship endpoint constraints, declarative MCP tools, optional conflict rules, seeds). One engine process mounts N domains: `/{domain}/api/v1/...`, MCP endpoint per domain, **database file per domain**, shared auth, domain-blind sync (`domain` field; per-domain `server_seq` + digest). House first (byte-identical, gated by the conformance suite), then `domains/garage` (cars, bays, issues, service records — the as-of machinery applied to new nouns). **Cross-domain queries: out of scope. Cross-domain references: supported by value** — an interval edge in the owning domain with a `(domain, entity_id)` remote endpoint; best-effort dereference; soft validation; dangling reported, never cascaded; `find_references_to` as the explicit above-the-boundary reverse lookup.
+
+**D9 — Tests and packaging (ADR-010).** Real-server harness as the default; a protocol conformance suite parameterized by domain manifest (the compatibility gate for every client, and the byte-identical gate for the abstraction step); 80% floor on `inbetweenies/`; one uv workspace (incl. domain packages), `>=3.11` everywhere.
+
+---
+
+## 4. Sequencing (proposal — nothing starts until review completes)
+
+| Phase | Work | ADRs | Risk |
+|---|---|---|---|
+| 0 | **Pull-guard fix in both clients** (#69) — independent of all design work | 011 | Low; live data-loss bug |
+| 1 | Delete dead stack; GraphIndex ownership + invalidation | 008, 003 | Low |
+| 2 | Access layer in SQL (`is_latest`, `server_seq`, pagination); strings-for-enums + domain manifest extraction (house, byte-identical) | 002, 012 | Medium — schema migrations, both installs controlled |
+| 3 | Temporal model (interval edges, tombstones, snapshot/diff); protocol v3 (ladder, atomic batches, digest, history-carrying delta); client temporal replicas | 004, 005, 011, 009 | Medium-high — coordinated server+client, the core of the redesign |
+| 4 | FTS5 search; garage domain instantiation | 006, 012 | Low — additive |
+| ongoing | Conformance suite, coverage floor, workspace | 010 | — |
+
+## 5. ADR index
+
+| ADR | Title | Status |
+|---|---|---|
+| 001 | Primary datastore — SQLite stays; Postgres exit criteria | Proposed |
+| 002 | Latest-version and delta queries move into SQL | Proposed |
+| 003 | GraphIndex ownership, invalidation, concurrency posture | Proposed |
+| 004 | Temporal model — as-of queries, interval edges, bitemporal-lite | Proposed (v2) |
+| 005 | Inbetweenies v3 — resolution ladder, clamped LWW, no HLC | Proposed (v2) |
+| 006 | Search — FTS5 now, sqlite-vec when embeddings have an owner | Proposed |
+| 007 | Blob externalization | **Withdrawn** (blobs stay in-row; 500 MB tripwire) |
+| 008 | Delete the dead sync stack | Proposed |
+| 009 | Client as temporal replica — time is always a parameter | Proposed (v2) |
+| 010 | Tests and packaging | Proposed |
+| 011 | Sync robustness — no write is ever silently lost | Proposed |
+| 012 | Domain abstraction — engine + house/garage; cross-domain references by value | Proposed |
+
+*Related issues: adrianco/the-goodies#69 (pull-guard, F1) · rolandcanyon-cmd/the-goodies-typescript#3 (KittenKong sync acks).*


### PR DESCRIPTION
## What this is

The full design & implementation review of the-goodies at `d00749b` (v0.3.0), plus **twelve ADRs** recording where the design discussion landed. **Documentation only — zero code changes.** Implementation is deliberately deferred; this PR exists so the ADRs can be reviewed, argued with, and amended as documents before anything is built.

- `docs/design-review-2026-08.md` — the overview: **findings** (measured — Graphify graph, full test run, live-instance numbers) separated from **decisions** (where discussion landed), with each reversal of the reviewer's first recommendation stated explicitly (HLC withdrawn, blob externalization withdrawn, retention pruning withdrawn, latest-only clients withdrawn).
- `docs/adr/ADR-001..012` — one decision per file, alternatives-considered included. ADR-007 is checked in as **Withdrawn** deliberately, so the blob decision and its 500 MB tripwire are on the record.

## Decision headlines

| Area | Decision |
|---|---|
| Engine | SQLite stays; bottleneck is Python-side full-history scans, fixed in SQL (001/002) |
| Blobs | Stay in-row — single-file consistent backup (007 withdrawn) |
| Time | Interval edges + `snapshot(at)`; client edit time = query axis, `server_seq` = replication axis; keep all history (004) |
| Sync | v3 ladder: fast-forward → per-type rules → 3-way DAG merge → clamped LWW; losers preserved; atomic batches; convergence digest; **no HLC** (005/011) |
| Clients | Full temporal replicas; every query takes `at`, omitted = now; read-your-writes at every point in time (009) |
| Domains | Generic engine + `domains/house` / `domains/garage`; DB file per domain; shared auth/sync; cross-domain **references by value**, no cross-domain queries (012) |

## Known live bug, sequenced first

#69 (client pull overwrites unpushed local edits — silent data loss) is independent of all of the above and phase 0 in the proposed sequencing.

## Review notes

The sharpest things to push back on: the valid-time-as-query-axis retroactivity trade-off (004 §2), the soft-validation posture on cross-domain references (012 §4), and the accepted-lineage snapshot rule (004 §3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCn4S4yjKMFF3FyczcddGY