### PR TITLE
chore(graphify): CI graph rebuild (ADR-010 §5) + project CLAUDE.md section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,3 +334,62 @@ jobs:
 
           # 4. Dependency set is internally consistent.
           "$VENV_PY" -m pip check
+
+  knowledge-graph:
+    name: Knowledge Graph
+    # ADR-010 section 5: keep the graph, and its dead-code signal, fresh.
+    #
+    # main only. On a PR the graph would describe a branch nobody has merged,
+    # and the dead-code signal is only meaningful against the trunk.
+    #
+    # This job is allowed to FAIL the build, deliberately. graphify extracts via
+    # tree-sitter, so a failed rebuild means the repo stopped parsing -- a real
+    # signal, not tooling noise. No `|| true`: this repo has been bitten four
+    # times by CI steps that reported success without checking anything --
+    # `pytest || true`, validate-dependencies' `|| echo` no-ops, that same job
+    # silently importing from the checkout because it inherited the
+    # workflow-level PYTHONPATH, and graphify's own post-commit hook, which
+    # backgrounds its rebuild so a failure never reaches git. The graph is not
+    # committed -- graphify-out/ is gitignored -- so the artifact upload is
+    # what makes this job's output reachable.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Install graphify
+        # Pinned below 1.0: pre-1.0 minors are not guaranteed compatible, and a
+        # silent bump would change the graph under us without a code change.
+        run: pip install "graphifyy<1.0"
+
+      - name: Rebuild the knowledge graph
+        run: graphify update .
+
+      - name: Report graph size
+        run: |
+          python - <<'PY'
+          import json, pathlib
+          graph = json.loads(pathlib.Path("graphify-out/graph.json").read_text())
+          # NetworkX node-link format: edges live under "links", not "edges".
+          nodes, links = graph.get("nodes", []), graph.get("links", [])
+          print(f"nodes={len(nodes)} edges={len(links)}")
+          if not nodes:
+              raise SystemExit("graph is empty -- extraction produced nothing")
+          PY
+
+      - name: Upload graph and report
+        uses: actions/upload-artifact@v7
+        with:
+          name: knowledge-graph
+          path: |
+            graphify-out/graph.json
+            graphify-out/GRAPH_REPORT.md
+          retention-days: 30
+          if-no-files-found: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,3 +550,13 @@ ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested by the User.
 Never save working files, text/mds and tests to the root folder.
 ALWAYS create and maintain a context summary at the start of each code file that records design choices and change history
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+Rules:
+- For codebase questions, first run `graphify query "<question>"` when graphify-out/graph.json exists. Use `graphify path "<A>" "<B>"` for relationships and `graphify explain "<concept>"` for focused concepts. These return a scoped subgraph, usually much smaller than GRAPH_REPORT.md or raw grep output.
+- If graphify-out/wiki/index.md exists, use it for broad navigation instead of raw source browsing.
+- Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).


### PR DESCRIPTION
Wires graphify in properly. It earned this: in the ADR-008 sweep its **method-level** edges caught that `blowingoff`'s `ConflictResolver` was instantiated but never invoked — ten inbound edges on the class, zero on every method. Grep can't see that; it finds three importers and concludes the code is alive.

## CI job (ADR-010 §5)

`knowledge-graph` rebuilds on pushes to **main only** and uploads `graph.json` + `GRAPH_REPORT.md` as an artifact.

- *main only* — on a PR the graph would describe a branch nobody has merged, and the dead-code signal is only meaningful against the trunk.
- *artifact upload is the point* — `graphify-out/` is gitignored, so without it a CI rebuild is discarded and the job proves nothing.
- *allowed to fail the build* — extraction is tree-sitter, so a failed rebuild means the repo stopped parsing. No `|| true`.

That last point is pointed. This repo has now been bitten **three times** by CI steps reporting success without checking anything: `pytest || true`, `validate-dependencies`' `|| echo "...test completed"`, and — as of today — graphify's own post-commit hook.

## Correction to how the hooks behave

The local hooks are installed and verified working (they fired on branch switch and on the commit in this PR). But the failure behaviour isn't as advertised:

> *"if a rebuild fails the hook exits non-zero so git surfaces the error"*

It can't. The hook ends in `subprocess.Popen(..., start_new_session=True)` — the rebuild is detached, so the `sys.exit(1)` on failure belongs to a child git never waits for. Failures land silently in `~/.cache/graphify-rebuild.log`. Even synchronously it couldn't block anything: `post-commit` and `post-checkout` both run *after* the operation. The CI job is the version that actually fails visibly.

The hook is otherwise well built — it probes for the `graphify` package rather than assuming the launcher is on PATH, which matters here because it isn't.

## Two bugs in my own first draft

Both caught by verifying instead of assuming:

- `actions/upload-artifact@v5` **doesn't exist**. Latest is v7 — matching the `checkout@v7`/`setup-python@v7` already in this workflow.
- `graph.json` is NetworkX node-link format, so edges live under `links`, not `edges`. My size check read the wrong key and would have printed `edges=0` on every run *while still passing*.

## Deliberately not committed

`graphify claude install` also wrote `.claude/settings.json`, registering PreToolUse hooks that shell out on every `Bash|Grep|Read|Glob` (~90ms each) to inject a `MANDATORY: run graphify query first` directive. Measured, doesn't block. But that's a per-developer workflow preference, not a project decision, so it stays untracked. Remove with `graphify claude uninstall`.

I also removed the `.gitattributes` that `hook install` created (`graphify-out/graph.json merge=graphify`): `graphify-out/` is gitignored, so the rule can never fire, and committing it would tell collaborators to use a merge driver none of them have configured.