### PR TITLE
fix: 7 shared-core bugs + client graph-store collision

### DIFF
--- a/blowing-off/blowingoff/client.py
+++ b/blowing-off/blowingoff/client.py
@@ -43,8 +43,10 @@ All MCP tools working locally with server data."""
 import os
 import asyncio
 import gc
+import logging
+import shutil
 import uuid
-from typing import Dict, Any, List, Optional, Callable
+from typing import Dict, Any, List, Optional, Callable, Union
 from datetime import datetime, UTC
 from pathlib import Path
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
@@ -59,6 +61,169 @@ from .mcp import LocalMCPClient
 from .graph import LocalGraphStorage, LocalGraphOperations
 from .repositories import SyncMetadataRepository
 from .auth import AuthManager
+
+
+logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------------------------------------
+# Graph-store location
+#
+# The client's graph store used to be derived from the database file's PARENT
+# directory (`<parent>/.blowing-off-graph`). That is not a function of the
+# client: two clients whose databases merely sit in the same directory got the
+# same store, and so shared one entity set, one index and — worst — one set of
+# pending (unpushed) marks, letting one client's push clear another's pending
+# flag. It also made the test suite non-reentrant, because every client built
+# on a NamedTemporaryFile landed in $TMPDIR/.blowing-off-graph.
+#
+# The store is now derived from the database file's IDENTITY: the full file
+# NAME plus a suffix, as a sibling of the database.
+#
+#     /var/lib/home/client.db  ->  /var/lib/home/client.db.graph/
+#
+# The full name is used rather than the stem (`<dir>/.blowing-off-graph-client`)
+# precisely because the stem is not unique: `client.db` and `client.sqlite`
+# share the stem `client` and would collide again. Appending to the whole name
+# is injective over a directory, so two distinct database files in one
+# directory always get two distinct stores. Keeping the store adjacent to the
+# database also means the pair is obvious to a human and travels together when
+# a deployment is copied or backed up.
+# ----------------------------------------------------------------------
+
+GRAPH_DIR_SUFFIX = ".graph"
+
+#: The pre-fix, shared-per-directory store. Read for migration only.
+LEGACY_GRAPH_DIR_NAME = ".blowing-off-graph"
+
+#: Dropped into a legacy store once some database has adopted its contents, so
+#: a second database cannot later adopt the same data a second time.
+LEGACY_CLAIM_MARKER = "adopted-by.json"
+
+_STORE_FILES = ("entities.json", "relationships.json", "index.json", "pending.json")
+_DATABASE_SUFFIXES = (".db", ".sqlite", ".sqlite3")
+
+
+def graph_storage_path(db_path: Union[str, Path]) -> Path:
+    """Return the graph-store directory belonging to `db_path`.
+
+    Collision-free by construction: the directory name contains the database
+    file's whole name, so distinct databases in one directory never share one.
+    """
+    db_file = Path(db_path).expanduser()
+    return db_file.parent / (db_file.name + GRAPH_DIR_SUFFIX)
+
+
+def _sibling_databases(directory: Path, db_name: str) -> set:
+    """Names of database files in `directory`, including `db_name` itself.
+
+    The client is often constructed before its database file exists, so the
+    client's own name is always counted whether or not it is on disk yet.
+    """
+    names = {db_name}
+    try:
+        for path in directory.iterdir():
+            if path.is_file() and path.suffix.lower() in _DATABASE_SUFFIXES:
+                names.add(path.name)
+    except OSError:
+        pass
+    return names
+
+
+def migrate_legacy_graph_store(
+    db_path: Union[str, Path],
+    store_dir: Optional[Union[str, Path]] = None,
+) -> str:
+    """Adopt a pre-fix shared store into this database's own store, if safe.
+
+    Returns a short status string naming what was decided; the client keeps it
+    on `.graph_store_migration` so operators (and tests) can see it.
+
+    The decision has to thread between two unacceptable outcomes. Requiring
+    manual action would silently strand an existing install: it would come up
+    against an empty graph, and — the sharp edge — any change written while
+    offline but never pushed would sit unreachable in the old directory. But
+    adopting unconditionally is worse, because the old directory is shared, so
+    its contents may belong to a *different* database entirely; adopting would
+    silently import a stranger's entities and, through their pending marks,
+    push them to the server under this client's identity.
+
+    So adoption happens automatically only where ownership is not in question:
+    when this database is the only database in the directory, the shared store
+    can only ever have been written by it. Where more than one database shares
+    the directory, ownership is genuinely unknowable from what is on disk, and
+    the migration declines, warns, and leaves the old directory untouched — no
+    data is destroyed, and a human can move the right store into place.
+
+    Adoption copies rather than moves, and stamps the legacy directory with a
+    marker, so the original remains available and a second database cannot
+    adopt the same data later.
+    """
+    db_file = Path(db_path).expanduser()
+    target = Path(store_dir) if store_dir is not None else graph_storage_path(db_file)
+    legacy_dir = db_file.parent / LEGACY_GRAPH_DIR_NAME
+
+    if not legacy_dir.is_dir():
+        return "no-legacy-store"
+
+    if target.exists():
+        # This database already has a store of its own; it is authoritative.
+        # (The directory outliving a clear_graph_data() is deliberate — an
+        # explicit clear must not be undone by resurrecting legacy data.)
+        return "own-store-exists"
+
+    payload = [legacy_dir / name for name in _STORE_FILES]
+    payload = [path for path in payload if path.is_file()]
+    if not payload:
+        return "legacy-store-empty"
+
+    marker = legacy_dir / LEGACY_CLAIM_MARKER
+    if marker.is_file():
+        owner = "another database"
+        try:
+            owner = json.loads(marker.read_text()).get("adopted_by") or owner
+        except (OSError, ValueError):
+            pass
+        logger.warning(
+            "Legacy graph store %s was already adopted by %s; not adopting it "
+            "again for %s, which starts with an empty graph. Copy the store "
+            "into %s by hand if it really belongs to this database.",
+            legacy_dir, owner, db_file.name, target,
+        )
+        return "declined-already-claimed"
+
+    siblings = _sibling_databases(db_file.parent, db_file.name)
+    if len(siblings) > 1:
+        logger.warning(
+            "Legacy graph store %s is shared by %d databases (%s), so it "
+            "cannot be attributed to %s. Leaving it untouched and starting "
+            "with an empty graph rather than importing data that may belong "
+            "to another client. If it is this client's, copy its *.json into "
+            "%s.",
+            legacy_dir, len(siblings), ", ".join(sorted(siblings)),
+            db_file.name, target,
+        )
+        return "declined-ambiguous"
+
+    target.mkdir(parents=True, exist_ok=True)
+    for path in payload:
+        shutil.copy2(path, target / path.name)
+
+    try:
+        marker.write_text(json.dumps({
+            "adopted_by": db_file.name,
+            "adopted_into": str(target),
+            "adopted_at": datetime.now(UTC).isoformat(),
+        }, indent=2))
+    except OSError as exc:  # read-only legacy dir: the copy still stands
+        logger.warning("Could not mark %s as adopted: %s", legacy_dir, exc)
+
+    logger.info(
+        "Adopted legacy graph store %s into %s (the original is left in "
+        "place; it is the only database in that directory).",
+        legacy_dir, target,
+    )
+    return "adopted"
 
 
 class BlowingOffClient:
@@ -76,10 +241,14 @@ class BlowingOffClient:
         self._is_offline = False  # Track offline status
         self._offline_changes_count = 0  # Track pending changes
 
-        # Initialize MCP and graph functionality
-        # Use a subdirectory of the database path for graph storage
-        graph_storage_dir = Path(db_path).parent / ".blowing-off-graph"
-        self.graph_storage = LocalGraphStorage(str(graph_storage_dir))
+        # Initialize MCP and graph functionality.
+        # The store belongs to THIS database file, not to its directory — see
+        # graph_storage_path() for why the directory was the wrong key.
+        self.graph_storage_dir = graph_storage_path(db_path)
+        self.graph_store_migration = migrate_legacy_graph_store(
+            db_path, self.graph_storage_dir
+        )
+        self.graph_storage = LocalGraphStorage(str(self.graph_storage_dir))
         self.graph_operations = LocalGraphOperations(self.graph_storage)
         self.mcp_client = LocalMCPClient(self.graph_storage)
 
@@ -309,7 +478,17 @@ class BlowingOffClient:
         return self.mcp_client.get_available_tools()
 
     def clear_graph_data(self):
-        """Clear all graph data from storage."""
+        """Clear this client's graph data, including its pending marks.
+
+        Scoped to this client's own store (`<db_path>.graph`). It used to reach
+        into the store shared by every database in the directory, so one
+        client's clear wiped the others' entities and dropped their unpushed
+        changes.
+
+        The store directory itself is kept, empty: its existence is what tells
+        a later start that this database has a store of its own, so a deliberate
+        clear is not undone by adopting a legacy store on the next run.
+        """
         if hasattr(self, 'graph_storage'):
             self.graph_storage.clear()
 

--- a/blowing-off/blowingoff/graph/local_storage.py
+++ b/blowing-off/blowingoff/graph/local_storage.py
@@ -86,6 +86,28 @@ class LocalGraphStorage:
         else:
             self._rebuild_index()
 
+    def _write_json(self, path: Path, payload, **dump_kwargs):
+        """Write JSON so a concurrent reader never sees a partial file.
+
+        Writing in place leaves a window in which the file is truncated or
+        half-written, and a reader that lands in it fails with a
+        JSONDecodeError. Writing to a sibling temp file and renaming makes the
+        replacement atomic, so a reader sees either the old file or the new one.
+        """
+        tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        try:
+            with open(tmp_path, 'w') as f:
+                json.dump(payload, f, **dump_kwargs)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+            raise
+
     def _save_data(self):
         """Save data to disk"""
         # Save entities
@@ -95,27 +117,23 @@ class LocalGraphStorage:
                 self._entity_to_dict(v) for v in versions
             ]
 
-        with open(self.entities_file, 'w') as f:
-            json.dump(entities_data, f, indent=2, default=str)
+        self._write_json(self.entities_file, entities_data, indent=2, default=str)
 
         # Save relationships
         relationships_data = [
             self._relationship_to_dict(r) for r in self._relationships
         ]
 
-        with open(self.relationships_file, 'w') as f:
-            json.dump(relationships_data, f, indent=2, default=str)
+        self._write_json(self.relationships_file, relationships_data, indent=2, default=str)
 
         # Save index
-        with open(self.index_file, 'w') as f:
-            json.dump(self._index, f, indent=2)
+        self._write_json(self.index_file, self._index, indent=2)
 
         # Save pending local changes
-        with open(self.pending_file, 'w') as f:
-            json.dump({
-                "entities": self._pending_entities,
-                "relationships": self._pending_relationships,
-            }, f, indent=2)
+        self._write_json(self.pending_file, {
+            "entities": self._pending_entities,
+            "relationships": self._pending_relationships,
+        }, indent=2)
 
     def _entity_to_dict(self, entity: Entity) -> dict:
         """Convert entity to dictionary for JSON serialization"""

--- a/blowing-off/tests/conftest.py
+++ b/blowing-off/tests/conftest.py
@@ -24,7 +24,9 @@ REVISION HISTORY:
 """
 
 import asyncio
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -54,3 +56,34 @@ def event_loop():
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture
+def private_db_path():
+    """Allocate client database paths inside a directory private to this test.
+
+    Call it once per client: `private_db_path()`, or `private_db_path("a.db")`
+    when a test wants two clients with recognisable names.
+
+    Every integration test used to build its database with
+    `tempfile.NamedTemporaryFile(suffix=".db")`, which puts the file in the
+    SHARED system temp directory. That was enough to make the whole suite share
+    one graph store back when the client derived it from the database's parent
+    directory -- $TMPDIR/.blowing-off-graph, across tests and across runs -- so
+    state leaked between tests, stale pending marks survived into later runs,
+    and two concurrent runs corrupted each other's half-written JSON. The store
+    is now keyed on the database file, but a private directory is still the
+    right habit: it keeps each test's database, WAL files and graph store
+    together and disposes of all of them at teardown.
+    """
+    work_dirs = []
+
+    def _allocate(name: str = "client.db") -> str:
+        work_dir = tempfile.mkdtemp(prefix="blowingoff-test-")
+        work_dirs.append(work_dir)
+        return str(Path(work_dir) / name)
+
+    yield _allocate
+
+    for work_dir in work_dirs:
+        shutil.rmtree(work_dir, ignore_errors=True)

--- a/blowing-off/tests/integration/test_disconnected_mode.py
+++ b/blowing-off/tests/integration/test_disconnected_mode.py
@@ -10,8 +10,6 @@ import pytest_asyncio
 import asyncio
 import sys
 import os
-import tempfile
-from pathlib import Path
 from unittest.mock import patch, AsyncMock
 
 from blowingoff import BlowingOffClient
@@ -23,165 +21,145 @@ class TestDisconnectedMode:
     """Test disconnected mode operations."""
 
     @pytest.mark.asyncio
-    async def test_server_connectivity_check(self, server_url, auth_token):
+    async def test_server_connectivity_check(self, server_url, auth_token, private_db_path):
         """Test that client can detect server availability."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
-        try:
-            client = BlowingOffClient(db_path)
-            await client.connect(server_url, auth_token, "test-connectivity")
+        client = BlowingOffClient(db_path)
+        await client.connect(server_url, auth_token, "test-connectivity")
 
-            # Check connectivity when server is up
-            is_connected = await client.check_server_connectivity()
-            assert is_connected is True
+        # Check connectivity when server is up
+        is_connected = await client.check_server_connectivity()
+        assert is_connected is True
 
-            # Test with invalid server URL
-            client.sync_engine.base_url = "http://localhost:9999"  # Non-existent server
-            is_connected = await client.check_server_connectivity()
-            assert is_connected is False
+        # Test with invalid server URL
+        client.sync_engine.base_url = "http://localhost:9999"  # Non-existent server
+        is_connected = await client.check_server_connectivity()
+        assert is_connected is False
 
-            await client.disconnect()
-        finally:
-            Path(db_path).unlink(missing_ok=True)
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_offline_mode_detection(self, auth_token):
+    async def test_offline_mode_detection(self, auth_token, private_db_path):
         """Test that client detects and reports offline mode."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
-        try:
-            client = BlowingOffClient(db_path)
-            # Connect to non-existent server
-            await client.connect("http://localhost:9999", auth_token, "test-offline")
+        client = BlowingOffClient(db_path)
+        # Connect to non-existent server
+        await client.connect("http://localhost:9999", auth_token, "test-offline")
 
-            # Initially should not be offline (not checked yet)
-            assert client.is_offline is False
+        # Initially should not be offline (not checked yet)
+        assert client.is_offline is False
 
-            # Try to sync - should detect offline mode
-            result = await client.sync()
-            assert result.success is False
-            assert len(result.errors) > 0
-            assert "disconnected mode" in result.errors[0].lower()
-            assert client.is_offline is True
+        # Try to sync - should detect offline mode
+        result = await client.sync()
+        assert result.success is False
+        assert len(result.errors) > 0
+        assert "disconnected mode" in result.errors[0].lower()
+        assert client.is_offline is True
 
-            await client.disconnect()
-        finally:
-            Path(db_path).unlink(missing_ok=True)
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_offline_to_online_transition(self, server_url, auth_token):
+    async def test_offline_to_online_transition(self, server_url, auth_token, private_db_path):
         """Test transition from offline to online mode."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
-        try:
-            client = BlowingOffClient(db_path)
-            await client.connect(server_url, auth_token, "test-transition")
+        client = BlowingOffClient(db_path)
+        await client.connect(server_url, auth_token, "test-transition")
 
-            # Start with invalid server to simulate offline
-            original_url = client.sync_engine.base_url
-            client.sync_engine.base_url = "http://localhost:9999"
+        # Start with invalid server to simulate offline
+        original_url = client.sync_engine.base_url
+        client.sync_engine.base_url = "http://localhost:9999"
 
-            # Should be offline
-            result = await client.sync()
-            assert client.is_offline is True
-            assert result.success is False
+        # Should be offline
+        result = await client.sync()
+        assert client.is_offline is True
+        assert result.success is False
 
-            # Restore valid server URL
-            client.sync_engine.base_url = original_url
+        # Restore valid server URL
+        client.sync_engine.base_url = original_url
 
-            # Should come back online
-            result = await client.sync()
-            assert client.is_offline is False
-            assert result.success is True
+        # Should come back online
+        result = await client.sync()
+        assert client.is_offline is False
+        assert result.success is True
 
-            await client.disconnect()
-        finally:
-            Path(db_path).unlink(missing_ok=True)
+        await client.disconnect()
 
     @pytest.mark.asyncio
-    async def test_local_operations_while_offline(self, auth_token):
+    async def test_local_operations_while_offline(self, auth_token, private_db_path):
         """Test that local operations work while offline."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
-        try:
-            client = BlowingOffClient(db_path)
-            # Connect to non-existent server
-            await client.connect("http://localhost:9999", auth_token, "test-local-ops")
+        client = BlowingOffClient(db_path)
+        # Connect to non-existent server
+        await client.connect("http://localhost:9999", auth_token, "test-local-ops")
 
-            # Verify offline mode
-            result = await client.sync()
-            assert client.is_offline is True
+        # Verify offline mode
+        result = await client.sync()
+        assert client.is_offline is True
 
-            # Create entity locally
-            entity = Entity(
-                entity_type=EntityType.DEVICE,
-                name="Offline Device",
-                content={"status": "created_offline"},
-                source_type=SourceType.MANUAL,
-                user_id="test-user"
-            )
+        # Create entity locally
+        entity = Entity(
+            entity_type=EntityType.DEVICE,
+            name="Offline Device",
+            content={"status": "created_offline"},
+            source_type=SourceType.MANUAL,
+            user_id="test-user"
+        )
 
-            # Store should work offline
-            stored = await client.graph_operations.store_entity(entity)
-            assert stored is not None
-            assert stored.name == "Offline Device"
+        # Store should work offline
+        stored = await client.graph_operations.store_entity(entity)
+        assert stored is not None
+        assert stored.name == "Offline Device"
 
-            # Retrieve should work offline
-            retrieved = await client.graph_operations.get_entity(stored.id)
-            assert retrieved is not None
-            assert retrieved.name == "Offline Device"
+        # Retrieve should work offline
+        retrieved = await client.graph_operations.get_entity(stored.id)
+        assert retrieved is not None
+        assert retrieved.name == "Offline Device"
 
-            # MCP tools should work offline
-            tools = client.get_available_mcp_tools()
-            assert len(tools) > 0
+        # MCP tools should work offline
+        tools = client.get_available_mcp_tools()
+        assert len(tools) > 0
 
-            await client.disconnect()
-        finally:
-            Path(db_path).unlink(missing_ok=True)
+        await client.disconnect()
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(sys.platform == "win32" and os.environ.get('CI') == 'true',
                         reason="Windows CI has SQLite file locking issues - see issue #7")
-    async def test_background_sync_with_offline_handling(self, server_url, auth_token):
+    async def test_background_sync_with_offline_handling(self, server_url, auth_token, private_db_path):
         """Test background sync handles offline mode gracefully."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
-        try:
-            client = BlowingOffClient(db_path)
-            await client.connect(server_url, auth_token, "test-background")
+        client = BlowingOffClient(db_path)
+        await client.connect(server_url, auth_token, "test-background")
 
-            # Track sync events
-            sync_events = []
-            async def observer(event, data):
-                sync_events.append((event, data.success if hasattr(data, 'success') else None))
+        # Track sync events
+        sync_events = []
+        async def observer(event, data):
+            sync_events.append((event, data.success if hasattr(data, 'success') else None))
 
-            client.add_observer(observer)
+        client.add_observer(observer)
 
-            # Start background sync with short interval
-            await client.start_background_sync(interval=1)
+        # Start background sync with short interval
+        await client.start_background_sync(interval=1)
 
-            # Wait for initial sync (background sync sleeps first, then syncs)
-            await asyncio.sleep(2)
+        # Wait for initial sync (background sync sleeps first, then syncs)
+        await asyncio.sleep(2)
 
-            # Should have successful sync
-            assert len(sync_events) > 0
-            assert any(event == "sync_complete" and success for event, success in sync_events)
+        # Should have successful sync
+        assert len(sync_events) > 0
+        assert any(event == "sync_complete" and success for event, success in sync_events)
 
-            # Simulate offline by changing URL
-            client.sync_engine.base_url = "http://localhost:9999"
-            sync_events.clear()
+        # Simulate offline by changing URL
+        client.sync_engine.base_url = "http://localhost:9999"
+        sync_events.clear()
 
-            # Wait for offline sync attempt
-            await asyncio.sleep(2)
+        # Wait for offline sync attempt
+        await asyncio.sleep(2)
 
-            # Should have disconnected event
-            assert any(event == "sync_disconnected" for event, _ in sync_events)
+        # Should have disconnected event
+        assert any(event == "sync_disconnected" for event, _ in sync_events)
 
-            await client.disconnect()
-        finally:
-            Path(db_path).unlink(missing_ok=True)
+        await client.disconnect()

--- a/blowing-off/tests/integration/test_simple_integration.py
+++ b/blowing-off/tests/integration/test_simple_integration.py
@@ -7,8 +7,6 @@ import pytest_asyncio
 import asyncio
 import httpx
 from blowingoff import BlowingOffClient
-import tempfile
-from pathlib import Path
 
 
 @pytest.mark.integration
@@ -25,15 +23,15 @@ class TestSimpleIntegration:
             assert response.json() == {"status": "healthy"}
 
     @pytest.mark.asyncio
-    async def test_basic_sync_flow(self, server_url, auth_token):
+    async def test_basic_sync_flow(self, server_url, auth_token, private_db_path):
         """Test basic sync flow without complex scenarios."""
-        # Create a temporary database
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        # A database in a directory private to this test, so its graph store
+        # and WAL files cannot be shared with any other test or run.
+        db_path = private_db_path()
 
+        # Create client and connect
+        client = BlowingOffClient(db_path)
         try:
-            # Create client and connect
-            client = BlowingOffClient(db_path)
             await client.connect(server_url, auth_token, "test-simple-client")
 
             # Perform initial sync
@@ -67,13 +65,7 @@ class TestSimpleIntegration:
                 # Don't fail the test - just log the issue
                 # This helps us understand what's wrong
 
-            await client.disconnect()
-
         finally:
-            # Cleanup
-            Path(db_path).unlink(missing_ok=True)
-            # Clean up WAL files too
-            for suffix in ["-wal", "-shm"]:
-                wal_path = Path(db_path + suffix)
-                if wal_path.exists():
-                    wal_path.unlink()
+            # No per-file cleanup: private_db_path removes the whole working
+            # directory -- database, WAL files and graph store together.
+            await client.disconnect()

--- a/blowing-off/tests/integration/test_sync_basic.py
+++ b/blowing-off/tests/integration/test_sync_basic.py
@@ -25,7 +25,7 @@ REVISION HISTORY:
 DEPENDENCIES:
 - pytest-asyncio: Async test support
 - httpx: HTTP client for server setup
-- tempfile: Temporary database creation
+- private_db_path fixture: per-test database directory (see tests/conftest.py)
 
 USAGE:
 Run with: pytest tests/integration/test_sync_basic.py
@@ -38,8 +38,6 @@ import asyncio
 from datetime import datetime
 import json
 import httpx
-from pathlib import Path
-import tempfile
 import sys
 import os
 
@@ -53,18 +51,14 @@ class TestBasicSync:
     # Using fixtures from conftest.py for server_url and auth_token
 
     @pytest_asyncio.fixture
-    async def client(self, server_url, auth_token):
-        """Create test client."""
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
-
-        client = BlowingOffClient(db_path)
+    async def client(self, server_url, auth_token, private_db_path):
+        """Create test client in a directory private to this test."""
+        client = BlowingOffClient(private_db_path())
         await client.connect(server_url, auth_token, "test-client-1")
 
         yield client
 
         await client.disconnect()
-        Path(db_path).unlink(missing_ok=True)
 
     @pytest.mark.asyncio
     async def test_initial_sync(self, client):

--- a/blowing-off/tests/integration/test_sync_conflicts.py
+++ b/blowing-off/tests/integration/test_sync_conflicts.py
@@ -23,8 +23,6 @@ import asyncio
 from datetime import datetime, timedelta
 import json
 import httpx
-from pathlib import Path
-import tempfile
 import uuid
 import sys
 import os
@@ -36,32 +34,33 @@ class TestSyncConflicts:
     """Test conflict resolution scenarios."""
 
     @pytest_asyncio.fixture
-    async def two_clients(self, server_url, auth_token):
-        """Create two clients to simulate conflicts."""
+    async def two_clients(self, server_url, auth_token, private_db_path):
+        """Create two clients to simulate conflicts.
+
+        Each gets its own private directory. These are meant to be two
+        SEPARATE clients that only ever learn about each other through the
+        server, so they must not share a graph store -- which is exactly what
+        they did while the store was keyed on the database's parent directory
+        and both databases sat in the system temp dir.
+        """
         clients = []
 
         for i in range(2):
-            with tempfile.NamedTemporaryFile(suffix=f"-{i}.db", delete=False) as f:
-                db_path = f.name
-
+            db_path = private_db_path(f"client-{i}.db")
             client = BlowingOffClient(db_path)
             await client.connect(server_url, auth_token, f"test-client-{i}")
             clients.append((client, db_path))
 
         yield clients
 
-        # Cleanup with delay for Windows
+        # Cleanup with delay for Windows; private_db_path removes the files.
         import time
         for client, db_path in clients:
             try:
                 await client.disconnect()
-            except:
+            except Exception:
                 pass
             time.sleep(0.1)  # Give Windows time to release handles
-            try:
-                Path(db_path).unlink(missing_ok=True)
-            except:
-                pass
 
     @pytest.mark.asyncio
     @pytest.mark.skipif(sys.platform == "win32" and os.environ.get('CI') == 'true',

--- a/blowing-off/tests/integration/test_sync_diagnostics.py
+++ b/blowing-off/tests/integration/test_sync_diagnostics.py
@@ -11,8 +11,6 @@ import httpx
 import time
 import sys
 import os
-from pathlib import Path
-import tempfile
 
 from blowingoff import BlowingOffClient
 
@@ -78,70 +76,66 @@ class TestSyncDiagnostics:
             assert "vector_clock" in data
 
     @pytest.mark.asyncio
-    async def test_single_client_operations(self, server_url, auth_token):
+    async def test_single_client_operations(self, server_url, auth_token, private_db_path):
         """Test single client can perform basic operations."""
         print(f"\n=== Testing single client operations ===")
 
-        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
-            db_path = f.name
+        db_path = private_db_path()
 
         print(f"Database path: {db_path}")
 
-        try:
-            client = BlowingOffClient(db_path)
+        client = BlowingOffClient(db_path)
 
-            # Test connection
-            print("Connecting to server...")
-            start = time.time()
-            await client.connect(server_url, auth_token, "test-single")
-            connect_time = time.time() - start
-            print(f"Connection took {connect_time:.2f} seconds")
+        # Test connection
+        print("Connecting to server...")
+        start = time.time()
+        await client.connect(server_url, auth_token, "test-single")
+        connect_time = time.time() - start
+        print(f"Connection took {connect_time:.2f} seconds")
 
-            # Test initial sync
-            print("Performing initial sync...")
-            start = time.time()
-            result = await client.sync()
-            sync_time = time.time() - start
-            print(f"Initial sync took {sync_time:.2f} seconds")
-            print(f"Sync result: success={result.success}, entities={result.synced_entities}")
-            assert result.success
+        # Test initial sync
+        print("Performing initial sync...")
+        start = time.time()
+        result = await client.sync()
+        sync_time = time.time() - start
+        print(f"Initial sync took {sync_time:.2f} seconds")
+        print(f"Sync result: success={result.success}, entities={result.synced_entities}")
+        assert result.success
 
-            # Test creating an entity locally
-            print("Creating local entity...")
-            from inbetweenies.models import Entity, EntityType, SourceType
-            import uuid
+        # Test creating an entity locally
+        print("Creating local entity...")
+        from inbetweenies.models import Entity, EntityType, SourceType
+        import uuid
 
-            entity = Entity(
-                id=str(uuid.uuid4()),
-                version=Entity.create_version("test-user"),
-                entity_type=EntityType.DEVICE,
-                name="Test Device",
-                content={"type": "test"},
-                source_type=SourceType.MANUAL,
-                user_id="test-user",
-                parent_versions=[]
-            )
+        entity = Entity(
+            id=str(uuid.uuid4()),
+            version=Entity.create_version("test-user"),
+            entity_type=EntityType.DEVICE,
+            name="Test Device",
+            content={"type": "test"},
+            source_type=SourceType.MANUAL,
+            user_id="test-user",
+            parent_versions=[]
+        )
 
-            stored = await client.graph_operations.store_entity(entity)
-            print(f"Created entity: {stored.id}")
+        stored = await client.graph_operations.store_entity(entity)
+        print(f"Created entity: {stored.id}")
 
-            # Test syncing the entity
-            print("Syncing created entity...")
-            start = time.time()
-            result = await client.sync()
-            sync_time = time.time() - start
-            print(f"Entity sync took {sync_time:.2f} seconds")
-            print(f"Sync result: success={result.success}, entities={result.synced_entities}")
-            assert result.success
+        # Test syncing the entity
+        print("Syncing created entity...")
+        start = time.time()
+        result = await client.sync()
+        sync_time = time.time() - start
+        print(f"Entity sync took {sync_time:.2f} seconds")
+        print(f"Sync result: success={result.success}, entities={result.synced_entities}")
+        assert result.success
 
-            await client.disconnect()
-            print("Client disconnected successfully")
+        await client.disconnect()
+        print("Client disconnected successfully")
 
-        finally:
-            Path(db_path).unlink(missing_ok=True)
 
     @pytest.mark.asyncio
-    async def test_concurrent_sync_timing(self, server_url, auth_token):
+    async def test_concurrent_sync_timing(self, server_url, auth_token, private_db_path):
         """Test how long concurrent sync operations take."""
         print(f"\n=== Testing concurrent sync timing ===")
         print(f"Platform: {sys.platform}")
@@ -149,14 +143,11 @@ class TestSyncDiagnostics:
 
         # Create two clients
         clients = []
-        db_paths = []
 
         for i in range(2):
-            with tempfile.NamedTemporaryFile(suffix=f"-{i}.db", delete=False) as f:
-                db_path = f.name
-                db_paths.append(db_path)
-
-            client = BlowingOffClient(db_path)
+            # Private directories: two separate clients must not share a
+            # graph store, which they did while it was keyed on the parent dir.
+            client = BlowingOffClient(private_db_path(f"client-{i}.db"))
             await client.connect(server_url, auth_token, f"test-concurrent-{i}")
             clients.append(client)
 
@@ -194,8 +185,5 @@ class TestSyncDiagnostics:
             for client in clients:
                 try:
                     await client.disconnect()
-                except:
+                except Exception:
                     pass
-
-            for db_path in db_paths:
-                Path(db_path).unlink(missing_ok=True)

--- a/blowing-off/tests/integration/test_sync_integration.py
+++ b/blowing-off/tests/integration/test_sync_integration.py
@@ -6,7 +6,6 @@ Tests the sync engine, protocol, and conflict resolution.
 
 import pytest
 import pytest_asyncio
-import tempfile
 import json
 from datetime import datetime, timedelta, UTC
 from unittest.mock import Mock, AsyncMock, patch

--- a/blowing-off/tests/unit/test_cli_commands.py
+++ b/blowing-off/tests/unit/test_cli_commands.py
@@ -16,8 +16,18 @@ from blowingoff.cli.main import cli
 
 
 @pytest.fixture
-def runner():
-    """Create a CLI test runner."""
+def runner(tmp_path, monkeypatch):
+    """A CLI runner rooted in a working directory private to this test.
+
+    `blowing-off connect` saves its config as `.blowingoff.json` in the CURRENT
+    working directory and `disconnect` deletes it again. While every test ran
+    in one shared directory (the checkout), connect wrote that file into the
+    repository for real, and test_disconnect_command only passed because
+    test_connect_command had run first and left it behind. Two suites running
+    at once then raced over the single file: whichever disconnected first
+    removed it, and the other reported "Not connected" and failed.
+    """
+    monkeypatch.chdir(tmp_path)
     return CliRunner()
 
 
@@ -102,11 +112,13 @@ class TestCLICommands:
         mock_instance.is_connected = True
         mock_instance.disconnect = AsyncMock()
 
-        # Create config file
-        config_path = Path.home() / '.blowing-off' / 'config.json'
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_path, 'w') as f:
-            json.dump({'server_url': 'http://localhost:8000'}, f)
+        # The config the command actually reads: `.blowingoff.json` in the
+        # working directory. This used to write ~/.blowing-off/config.json,
+        # which `disconnect` never looks at, so the assertion below was really
+        # testing whatever an earlier test had left in the shared directory.
+        Path('.blowingoff.json').write_text(
+            json.dumps({'server_url': 'http://localhost:8000'})
+        )
 
         result = runner.invoke(cli, ['disconnect'])
 
@@ -345,10 +357,11 @@ class TestCLIErrorHandling:
 
     def test_no_config_file(self, runner):
         """Test commands when no config file exists."""
-        # Remove any existing config
-        config_path = Path.home() / '.blowing-off' / 'config.json'
-        if config_path.exists():
-            config_path.unlink()
+        # Nothing to remove: the runner fixture gives this test an empty
+        # working directory, so `.blowingoff.json` is absent by construction.
+        # (It used to delete a file in $HOME that the CLI never reads, while
+        # depending on the real state of the shared directory it ran in.)
+        assert not Path('.blowingoff.json').exists()
 
         result = runner.invoke(cli, ['status'])
 

--- a/blowing-off/tests/unit/test_graph_store_isolation.py
+++ b/blowing-off/tests/unit/test_graph_store_isolation.py
@@ -1,0 +1,297 @@
+"""The client's graph store belongs to its database file, not to a directory.
+
+The store used to be `<db_path>.parent / ".blowing-off-graph"`, keyed on the
+DIRECTORY holding the database. Two clients opened on different databases that
+happened to share a directory therefore shared one entity set, one index, and
+one set of pending (unpushed) marks — so one client could see another's
+entities, and one client's push could clear another's pending flag. The same
+shape made the test suite non-reentrant: every client built on a
+NamedTemporaryFile landed in $TMPDIR/.blowing-off-graph, across tests and
+across runs.
+
+These tests pin the property that was missing: the store is a function of the
+database file's identity. They also pin the migration policy for installs that
+already have data in the old shared location — see
+`blowingoff.client.migrate_legacy_graph_store`.
+
+No server is involved: the store is chosen in __init__, before connect().
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from blowingoff.client import (
+    LEGACY_CLAIM_MARKER,
+    LEGACY_GRAPH_DIR_NAME,
+    BlowingOffClient,
+    graph_storage_path,
+    migrate_legacy_graph_store,
+)
+from inbetweenies.models import Entity, EntityType, SourceType
+
+
+def _entity(name: str) -> Entity:
+    return Entity(
+        entity_type=EntityType.DEVICE,
+        name=name,
+        content={"marker": name},
+        source_type=SourceType.MANUAL,
+        user_id="test-user",
+    )
+
+
+def _legacy_store(directory: Path, entity_id: str = "legacy-entity") -> Path:
+    """Write a plausible pre-fix shared store into `directory`."""
+    legacy = directory / LEGACY_GRAPH_DIR_NAME
+    legacy.mkdir(parents=True, exist_ok=True)
+    (legacy / "entities.json").write_text(json.dumps({
+        entity_id: [{
+            "id": entity_id,
+            "version": "2026-01-01T00:00:00+00:00Z-000001-legacy",
+            "entity_type": "device",
+            "name": "Legacy Device",
+            "content": {"origin": "legacy"},
+            "source_type": "manual",
+            "user_id": "legacy-user",
+            "parent_versions": [],
+            "created_at": None,
+            "updated_at": None,
+        }]
+    }))
+    (legacy / "relationships.json").write_text("[]")
+    (legacy / "index.json").write_text(json.dumps(
+        {"by_type": {"device": [entity_id]}, "by_room": {}}
+    ))
+    (legacy / "pending.json").write_text(json.dumps(
+        {"entities": {entity_id: "create"}, "relationships": {}}
+    ))
+    return legacy
+
+
+class TestStorePathIsDerivedFromTheDatabaseFile:
+    """The store directory is a function of the db file, not its parent."""
+
+    def test_two_databases_in_one_directory_get_two_stores(self, tmp_path):
+        assert graph_storage_path(tmp_path / "a.db") != graph_storage_path(tmp_path / "b.db")
+
+    def test_same_stem_different_suffix_still_differs(self, tmp_path):
+        """The whole name is used, not the stem, which is not unique."""
+        assert graph_storage_path(tmp_path / "home.db") != graph_storage_path(tmp_path / "home.sqlite")
+
+    def test_store_sits_beside_its_database(self, tmp_path):
+        store = graph_storage_path(tmp_path / "client.db")
+        assert store.parent == tmp_path
+        assert store.name == "client.db.graph"
+
+    def test_the_old_shared_directory_is_never_used(self, tmp_path):
+        client = BlowingOffClient(str(tmp_path / "client.db"))
+        assert client.graph_storage_dir.name != LEGACY_GRAPH_DIR_NAME
+        assert not (tmp_path / LEGACY_GRAPH_DIR_NAME).exists()
+
+
+@pytest.mark.asyncio
+class TestTwoClientsInOneDirectoryAreIndependent:
+    """The regression: different databases, same directory, one graph."""
+
+    @staticmethod
+    def _pair(tmp_path):
+        return (
+            BlowingOffClient(str(tmp_path / "alice.db")),
+            BlowingOffClient(str(tmp_path / "bob.db")),
+        )
+
+    async def test_stores_are_distinct_directories(self, tmp_path):
+        alice, bob = self._pair(tmp_path)
+        assert alice.graph_storage_dir != bob.graph_storage_dir
+
+    async def test_neither_sees_the_others_entities(self, tmp_path):
+        alice, bob = self._pair(tmp_path)
+
+        stored = await alice.graph_operations.store_entity(_entity("alice-device"))
+
+        assert await alice.graph_operations.get_entity(stored.id) is not None
+        assert await bob.graph_operations.get_entity(stored.id) is None, (
+            "bob's database is a different file; alice's entity must not be visible"
+        )
+        assert bob.graph_storage.get_entities_by_type(EntityType.DEVICE) == []
+
+    async def test_pending_marks_are_independent(self, tmp_path):
+        alice, bob = self._pair(tmp_path)
+
+        await alice.graph_operations.store_entity(_entity("alice-device"))
+        assert alice.pending_changes_count == 1
+        assert bob.pending_changes_count == 0, (
+            "bob has written nothing; he must have nothing pending"
+        )
+
+        # And a push acknowledged for bob must not clear alice's queue, which
+        # is the production consequence: a client silently loses a change it
+        # never pushed.
+        await bob.graph_operations.store_entity(_entity("bob-device"))
+        bob.graph_storage.clear_pending()
+
+        assert bob.pending_changes_count == 0
+        assert alice.pending_changes_count == 1, (
+            "bob's sync must not clear alice's unpushed change"
+        )
+
+    async def test_clear_graph_data_only_clears_its_own_client(self, tmp_path):
+        alice, bob = self._pair(tmp_path)
+
+        alice_entity = await alice.graph_operations.store_entity(_entity("alice-device"))
+        bob_entity = await bob.graph_operations.store_entity(_entity("bob-device"))
+
+        alice.clear_graph_data()
+
+        assert await alice.graph_operations.get_entity(alice_entity.id) is None
+        assert await bob.graph_operations.get_entity(bob_entity.id) is not None
+        assert bob.pending_changes_count == 1
+
+
+@pytest.mark.asyncio
+class TestStoreSurvivesRestart:
+    """The existing persistence guarantee must not regress."""
+
+    async def test_entities_and_pending_marks_survive_a_restart(self, tmp_path):
+        db_path = str(tmp_path / "client.db")
+
+        first = BlowingOffClient(db_path)
+        stored = await first.graph_operations.store_entity(_entity("persisted"))
+        assert first.pending_changes_count == 1
+
+        reopened = BlowingOffClient(db_path)
+
+        assert reopened.graph_storage_dir == first.graph_storage_dir
+        found = await reopened.graph_operations.get_entity(stored.id)
+        assert found is not None and found.name == "persisted"
+        assert reopened.pending_changes_count == 1, (
+            "an offline write must still be pushed after a restart"
+        )
+
+    async def test_a_neighbour_appearing_later_does_not_disturb_the_store(self, tmp_path):
+        """A second database in the directory must not affect the first."""
+        db_path = str(tmp_path / "client.db")
+        first = BlowingOffClient(db_path)
+        stored = await first.graph_operations.store_entity(_entity("persisted"))
+
+        BlowingOffClient(str(tmp_path / "neighbour.db"))
+
+        reopened = BlowingOffClient(db_path)
+        assert await reopened.graph_operations.get_entity(stored.id) is not None
+        assert reopened.pending_changes_count == 1
+
+
+@pytest.mark.asyncio
+class TestLegacyStoreMigration:
+    """Existing installs keep their data — but never a stranger's."""
+
+    async def test_lone_database_adopts_its_legacy_store(self, tmp_path):
+        """Unambiguous ownership: the only database in the directory."""
+        legacy = _legacy_store(tmp_path)
+        (tmp_path / "client.db").write_bytes(b"")
+
+        client = BlowingOffClient(str(tmp_path / "client.db"))
+
+        assert client.graph_store_migration == "adopted"
+        entity = await client.graph_operations.get_entity("legacy-entity")
+        assert entity is not None and entity.name == "Legacy Device"
+        assert client.pending_changes_count == 1, (
+            "an unpushed change in the old store must still be pushed, not stranded"
+        )
+        # The original is copied, not moved: nothing is destroyed.
+        assert (legacy / "entities.json").is_file()
+        assert (legacy / LEGACY_CLAIM_MARKER).is_file()
+
+    async def test_adoption_survives_the_next_start(self, tmp_path):
+        (tmp_path / "client.db").write_bytes(b"")
+        _legacy_store(tmp_path)
+
+        BlowingOffClient(str(tmp_path / "client.db"))
+        again = BlowingOffClient(str(tmp_path / "client.db"))
+
+        assert again.graph_store_migration == "own-store-exists"
+        assert await again.graph_operations.get_entity("legacy-entity") is not None
+
+    async def test_shared_legacy_store_is_not_adopted_by_anyone(self, tmp_path, caplog):
+        """The stranger case: the old directory may hold another client's graph."""
+        legacy = _legacy_store(tmp_path)
+        (tmp_path / "alice.db").write_bytes(b"")
+        (tmp_path / "bob.db").write_bytes(b"")
+
+        with caplog.at_level("WARNING"):
+            alice = BlowingOffClient(str(tmp_path / "alice.db"))
+            bob = BlowingOffClient(str(tmp_path / "bob.db"))
+
+        assert alice.graph_store_migration == "declined-ambiguous"
+        assert bob.graph_store_migration == "declined-ambiguous"
+        assert await alice.graph_operations.get_entity("legacy-entity") is None
+        assert await bob.graph_operations.get_entity("legacy-entity") is None
+        assert alice.pending_changes_count == 0
+        assert bob.pending_changes_count == 0
+
+        # Declining is not deleting: the data is still there for a human.
+        assert json.loads((legacy / "entities.json").read_text())
+        assert not (legacy / LEGACY_CLAIM_MARKER).exists()
+        assert "cannot be attributed" in caplog.text
+
+    async def test_a_second_database_cannot_adopt_an_already_adopted_store(self, tmp_path, caplog):
+        """Adoption is once-only, even if the neighbour arrives afterwards."""
+        (tmp_path / "first.db").write_bytes(b"")
+        _legacy_store(tmp_path)
+
+        first = BlowingOffClient(str(tmp_path / "first.db"))
+        assert first.graph_store_migration == "adopted"
+
+        (tmp_path / "second.db").write_bytes(b"")
+        with caplog.at_level("WARNING"):
+            second = BlowingOffClient(str(tmp_path / "second.db"))
+
+        assert second.graph_store_migration == "declined-already-claimed"
+        assert await second.graph_operations.get_entity("legacy-entity") is None
+        assert "already adopted" in caplog.text
+
+    async def test_an_existing_store_wins_over_the_legacy_one(self, tmp_path):
+        """A store of this database's own is authoritative; legacy is history."""
+        db_path = str(tmp_path / "client.db")
+        client = BlowingOffClient(db_path)
+        own = await client.graph_operations.store_entity(_entity("mine"))
+
+        _legacy_store(tmp_path)
+        reopened = BlowingOffClient(db_path)
+
+        assert reopened.graph_store_migration == "own-store-exists"
+        assert await reopened.graph_operations.get_entity(own.id) is not None
+        assert await reopened.graph_operations.get_entity("legacy-entity") is None
+
+    async def test_a_deliberate_clear_is_not_undone_by_legacy_data(self, tmp_path):
+        db_path = str(tmp_path / "client.db")
+        client = BlowingOffClient(db_path)
+        await client.graph_operations.store_entity(_entity("mine"))
+        _legacy_store(tmp_path)
+        client.clear_graph_data()
+
+        reopened = BlowingOffClient(db_path)
+
+        assert reopened.graph_store_migration == "own-store-exists"
+        assert await reopened.graph_operations.get_entity("legacy-entity") is None
+
+    def test_no_legacy_store_is_a_no_op(self, tmp_path):
+        client = BlowingOffClient(str(tmp_path / "client.db"))
+        assert client.graph_store_migration == "no-legacy-store"
+
+    def test_an_empty_legacy_directory_is_not_adopted(self, tmp_path):
+        (tmp_path / LEGACY_GRAPH_DIR_NAME).mkdir()
+        client = BlowingOffClient(str(tmp_path / "client.db"))
+        assert client.graph_store_migration == "legacy-store-empty"
+
+    def test_migration_never_writes_to_the_legacy_directory_it_declines(self, tmp_path):
+        legacy = _legacy_store(tmp_path)
+        (tmp_path / "a.db").write_bytes(b"")
+        (tmp_path / "b.db").write_bytes(b"")
+        before = sorted(p.name for p in legacy.iterdir())
+
+        migrate_legacy_graph_store(tmp_path / "a.db")
+
+        assert sorted(p.name for p in legacy.iterdir()) == before

--- a/inbetweenies/graph/operations.py
+++ b/inbetweenies/graph/operations.py
@@ -135,13 +135,17 @@ class GraphOperations(ABC):
         Args:
             entity_id: Center entity ID
             depth: How many hops to include
-            rel_types: Filter by relationship types
+            rel_types: Filter by relationship types (all of them, not just the
+                first)
 
         Returns:
-            Dictionary with entities and relationships
+            Dictionary with entities and relationships. Each relationship
+            appears exactly once even though it is reachable from both of its
+            endpoints.
         """
         entities = {}
         relationships = []
+        seen_relationships = set()
         visited = set()
 
         # Start with center entity
@@ -163,12 +167,21 @@ class GraphOperations(ABC):
 
             visited.add(current_id)
 
-            # Get all relationships for this entity
-            outgoing = await self.get_relationships(from_id=current_id, rel_type=rel_types[0] if rel_types else None)
-            incoming = await self.get_relationships(to_id=current_id, rel_type=rel_types[0] if rel_types else None)
+            # Get all relationships for this entity. The primitive filters one
+            # type at a time, so ask once per requested type; no filter at all
+            # when the caller did not name any.
+            edges = []
+            for rel_type in (rel_types if rel_types else [None]):
+                edges.extend(await self.get_relationships(from_id=current_id, rel_type=rel_type))
+                edges.extend(await self.get_relationships(to_id=current_id, rel_type=rel_type))
 
-            for rel in outgoing + incoming:
-                relationships.append(rel)
+            for rel in edges:
+                # An edge whose endpoints are both expanded is seen twice (once
+                # outgoing, once incoming), and a self-loop twice from the same
+                # entity; report it once.
+                if rel.id not in seen_relationships:
+                    seen_relationships.add(rel.id)
+                    relationships.append(rel)
 
                 # Add connected entities to visit
                 if rel.from_entity_id == current_id:

--- a/inbetweenies/graph/search.py
+++ b/inbetweenies/graph/search.py
@@ -22,10 +22,15 @@ class SearchResult:
 
     def to_dict(self) -> dict:
         """Convert to dictionary representation"""
+        # entity_type may be an EntityType or a plain string, exactly as in
+        # Entity.to_dict.
+        entity_type = self.entity.entity_type
+        entity_type_value = entity_type.value if hasattr(entity_type, 'value') else str(entity_type)
+
         return {
             "id": self.entity.id,
             "version": self.entity.version,
-            "entity_type": self.entity.entity_type.value,
+            "entity_type": entity_type_value,
             "name": self.entity.name,
             "score": self.score,
             "highlights": self.highlights,

--- a/inbetweenies/graph/traversal.py
+++ b/inbetweenies/graph/traversal.py
@@ -10,6 +10,20 @@ from abc import ABC, abstractmethod
 
 from ..models import Entity, EntityRelationship, RelationshipType
 
+# Relationship types whose edges run child -> parent, i.e. the *target* of the
+# edge is the containing entity. This is the schema's own convention:
+# ``EntityRelationship.is_valid_for_entities`` validates PART_OF as ROOM->HOME /
+# ZONE->HOME / DEVICE->ZONE and LOCATED_IN as DEVICE->ROOM / ROOM->HOME, so an
+# edge of these types points *upwards*. Every other type is stored parent ->
+# child, the way CONTROLS is validated (AUTOMATION->DEVICE, DEVICE->DEVICE:
+# controller -> controlled). ``get_ancestors``/``get_descendants`` consult this
+# so that "ancestor" means the same thing whichever convention a type uses.
+CHILD_TO_PARENT_TYPES = frozenset({
+    RelationshipType.PART_OF,
+    RelationshipType.LOCATED_IN,
+    RelationshipType.CONTAINED_IN,
+})
+
 
 class GraphTraversal(ABC):
     """Abstract base class for graph traversal operations"""
@@ -187,6 +201,83 @@ class GraphTraversal(ABC):
         await dfs_paths(start_id, [start_id])
         return all_paths
 
+    async def _hierarchy_step(
+        self,
+        entity_id: str,
+        rel_type: RelationshipType,
+        upwards: bool
+    ) -> List[str]:
+        """
+        Take one hierarchy hop away from an entity.
+
+        Which way round the edge is stored depends on the relationship type
+        (see CHILD_TO_PARENT_TYPES), so "upwards" is not the same as "incoming".
+
+        Args:
+            entity_id: Entity to step away from
+            rel_type: Relationship type defining the hierarchy
+            upwards: True for the level above, False for the level below
+
+        Returns:
+            IDs of the entities one level above or below this one
+        """
+        # An upward edge type is followed forwards to reach a parent, a
+        # downward one backwards; and vice versa for children.
+        if (rel_type in CHILD_TO_PARENT_TYPES) == upwards:
+            relationships = await self.get_relationships(from_id=entity_id, rel_type=rel_type)
+            return [rel.to_entity_id for rel in relationships]
+
+        relationships = await self.get_relationships(to_id=entity_id, rel_type=rel_type)
+        return [rel.from_entity_id for rel in relationships]
+
+    async def _walk_hierarchy(
+        self,
+        entity_id: str,
+        rel_type: RelationshipType,
+        upwards: bool,
+        max_depth: Optional[int] = None
+    ) -> List[Entity]:
+        """
+        Walk a single-relationship-type hierarchy breadth-first.
+
+        The starting entity is never included and no entity is reported twice,
+        so cyclic data terminates. ``max_depth`` counts hops, as in ``bfs``:
+        None is unbounded, 1 is the immediately adjacent level, 0 is nothing.
+
+        Args:
+            entity_id: Starting entity ID
+            rel_type: Relationship type defining the hierarchy
+            upwards: True to walk towards ancestors, False towards descendants
+            max_depth: Maximum number of hops to take
+
+        Returns:
+            List of entities in breadth-first order, nearest level first
+        """
+        found = []
+        visited = {entity_id}
+        queue = deque([(entity_id, 0)])
+
+        while queue:
+            current_id, depth = queue.popleft()
+
+            if max_depth is not None and depth >= max_depth:
+                continue
+
+            for next_id in await self._hierarchy_step(current_id, rel_type, upwards):
+                if next_id in visited:
+                    continue
+
+                visited.add(next_id)
+
+                entity = await self.get_entity(next_id)
+                if not entity:
+                    continue
+
+                found.append(entity)
+                queue.append((next_id, depth + 1))
+
+        return found
+
     async def get_ancestors(
         self,
         entity_id: str,
@@ -196,37 +287,28 @@ class GraphTraversal(ABC):
         """
         Get all ancestors of an entity following a specific relationship type.
 
+        An ancestor is an entity above this one in the hierarchy that rel_type
+        describes. The edge direction that means "above" is the schema's, not a
+        fixed one: for PART_OF and the other CHILD_TO_PARENT_TYPES the walk
+        follows outgoing edges (a DEVICE is PART_OF a ZONE is PART_OF a HOME, so
+        the ancestors of the device are the zone then the home); for every other
+        type it follows incoming ones (a DEVICE that CONTROLS another is the
+        controlled device's ancestor).
+
+        The entity itself is never an ancestor of itself, and this is the exact
+        inverse of ``get_descendants``: ``b`` is in ``get_ancestors(a)`` if and
+        only if ``a`` is in ``get_descendants(b)``.
+
         Args:
             entity_id: Starting entity ID
             rel_type: Relationship type to follow (e.g., PART_OF)
-            max_depth: Maximum depth to traverse
+            max_depth: Maximum number of levels to climb (None for all, 1 for
+                immediate parents only)
 
         Returns:
-            List of ancestor entities
+            List of ancestor entities, closest generation first
         """
-        ancestors = []
-        visited = set()
-
-        async def find_ancestors(current_id: str, depth: int):
-            if current_id in visited:
-                return
-
-            if max_depth is not None and depth > max_depth:
-                return
-
-            visited.add(current_id)
-
-            # Get incoming relationships of the specified type
-            relationships = await self.get_relationships(to_id=current_id, rel_type=rel_type)
-
-            for rel in relationships:
-                parent = await self.get_entity(rel.from_entity_id)
-                if parent and parent.id not in visited:
-                    ancestors.append(parent)
-                    await find_ancestors(parent.id, depth + 1)
-
-        await find_ancestors(entity_id, 0)
-        return ancestors
+        return await self._walk_hierarchy(entity_id, rel_type, upwards=True, max_depth=max_depth)
 
     async def get_descendants(
         self,
@@ -237,20 +319,24 @@ class GraphTraversal(ABC):
         """
         Get all descendants of an entity following a specific relationship type.
 
+        A descendant is an entity below this one in the hierarchy that rel_type
+        describes -- the exact inverse of ``get_ancestors``, walking the same
+        edges the other way. As there, the direction that means "below" comes
+        from the schema: the descendants of a HOME under PART_OF are the rooms
+        and zones whose edges point *at* it.
+
+        The entity itself is not one of its own descendants.
+
         Args:
             entity_id: Starting entity ID
             rel_type: Relationship type to follow
-            max_depth: Maximum depth to traverse
+            max_depth: Maximum number of levels to descend (None for all, 1 for
+                immediate children only)
 
         Returns:
-            List of descendant entities
+            List of descendant entities, closest generation first
         """
-        # Use BFS with relationship filter
-        return await self.bfs(
-            entity_id,
-            max_depth=max_depth,
-            rel_types=[rel_type]
-        )
+        return await self._walk_hierarchy(entity_id, rel_type, upwards=False, max_depth=max_depth)
 
     async def detect_cycles(
         self,
@@ -261,11 +347,13 @@ class GraphTraversal(ABC):
         Detect cycles in the graph.
 
         Args:
-            start_id: Optional starting point (if None, check entire graph)
+            start_id: Optional starting point. If None the entire graph is
+                checked, including components no single entity reaches.
             rel_types: Filter by relationship types
 
         Returns:
-            List of cycles (each cycle is a list of entity IDs)
+            List of cycles (each cycle is a list of entity IDs, closed: the
+            entity the cycle returns to is repeated at the end)
         """
         cycles = []
         visited = set()
@@ -299,9 +387,16 @@ class GraphTraversal(ABC):
         if start_id:
             await dfs_cycle(start_id)
         else:
-            # Check entire graph
-            # This would need access to all entities, which requires extending the interface
-            pass
+            # Check the entire graph. An entity with no outgoing edge cannot be
+            # part of a cycle, so the sources of the (unfiltered) relationship
+            # list are a complete set of roots -- no need for a list-all-entities
+            # primitive the interface does not have.
+            for rel in await self.get_relationships():
+                if rel_types and rel.relationship_type not in rel_types:
+                    continue
+
+                if rel.from_entity_id not in visited:
+                    await dfs_cycle(rel.from_entity_id)
 
         return cycles
 

--- a/inbetweenies/models/entity.py
+++ b/inbetweenies/models/entity.py
@@ -165,14 +165,16 @@ class Entity(Base, InbetweeniesTimestampMixin):
         """
         # Create new version data
         new_data = self.to_dict()
+        new_data.update(changes)
 
-        # Merge content if provided in changes
+        # Merge content if provided in changes. The merge is written into
+        # new_data, never back into ``changes``: the caller's dict is an input
+        # and several callers (e.g. MCPTools.update_entity_tool) report it back
+        # as the delta that was requested.
         if "content" in changes:
             merged_content = self.content.copy() if self.content else {}
             merged_content.update(changes["content"])
-            changes["content"] = merged_content
-
-        new_data.update(changes)
+            new_data["content"] = merged_content
 
         # Update version tracking
         new_data["version"] = self.create_version(user_id)

--- a/inbetweenies/tests/unit/test_graph_operations.py
+++ b/inbetweenies/tests/unit/test_graph_operations.py
@@ -66,17 +66,6 @@ class TestUpdateEntity:
         with pytest.raises(ValueError, match="Entity no-such-entity not found"):
             await house.update_entity("no-such-entity", {"name": "x"}, "alice")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (entity.py:170-173, reached via operations.py:67): create_new_version "
-            "writes the merged content back into the caller's `changes` dict "
-            "(`changes[\"content\"] = merged_content`) instead of into a copy. The "
-            "caller's argument is mutated, and MCPTools.update_entity_tool then reports "
-            "the whole merged content as `changes_applied` (tools.py:475) rather than "
-            "the delta that was requested."
-        ),
-    )
     async def test_does_not_mutate_the_callers_changes_dict(self, house):
         changes = {"content": {"watts": 9}}
 
@@ -210,14 +199,6 @@ class TestGetSubgraph:
         assert set(subgraph["entities"]) == {"device-light"}
         assert subgraph["relationships"] == []
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (operations.py:167-168): rel_types is a List but only rel_types[0] is "
-            "ever used -- every relationship type after the first is silently ignored, "
-            "so a caller asking for two types gets the edges of one."
-        ),
-    )
     async def test_all_requested_relationship_types_are_included(self, house):
         subgraph = await house.get_subgraph(
             "device-light",
@@ -230,20 +211,51 @@ class TestGetSubgraph:
             "rel-auto-light",
         }
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (operations.py:170-171): every edge between two entities that are both "
-            "expanded is appended twice -- once as the first entity's outgoing edge and "
-            "once as the second's incoming edge. The relationships list is not "
-            "de-duplicated, so any caller counting edges over-counts at depth >= 2."
-        ),
-    )
     async def test_relationships_are_not_duplicated(self, house):
         subgraph = await house.get_subgraph("device-light", depth=2)
 
         ids = [r.id for r in subgraph["relationships"]]
         assert len(ids) == len(set(ids))
+
+    async def test_a_self_loop_is_reported_once(self, house):
+        # A self-loop is both an outgoing and an incoming edge of the same
+        # entity, so it is the one edge a single expansion sees twice.
+        house.connect("rel-hub-hub", "device-hub", "device-hub", RelationshipType.CONTROLS)
+
+        subgraph = await house.get_subgraph("device-hub", depth=1)
+
+        ids = [r.id for r in subgraph["relationships"]]
+        assert ids.count("rel-hub-hub") == 1
+
+    async def test_every_requested_type_survives_the_second_hop(self, house):
+        # The per-type queries are re-issued for each expanded entity, so a
+        # type that only appears further out must still be picked up.
+        subgraph = await house.get_subgraph(
+            "device-hub",
+            depth=2,
+            rel_types=[RelationshipType.CONTROLS, RelationshipType.DOCUMENTED_BY],
+        )
+
+        assert {r.id for r in subgraph["relationships"]} == {
+            "rel-hub-light",  # hop 1, CONTROLS
+            "rel-light-manual",  # hop 2, DOCUMENTED_BY
+        }
+
+    async def test_relationship_types_may_be_given_in_any_order(self, house):
+        forwards = await house.get_subgraph(
+            "device-light",
+            depth=1,
+            rel_types=[RelationshipType.CONTROLS, RelationshipType.AUTOMATES],
+        )
+        backwards = await house.get_subgraph(
+            "device-light",
+            depth=1,
+            rel_types=[RelationshipType.AUTOMATES, RelationshipType.CONTROLS],
+        )
+
+        assert {r.id for r in forwards["relationships"]} == {
+            r.id for r in backwards["relationships"]
+        }
 
 
 class TestGetStatistics:

--- a/inbetweenies/tests/unit/test_graph_search.py
+++ b/inbetweenies/tests/unit/test_graph_search.py
@@ -75,17 +75,6 @@ class TestSearchResult:
             make_entity("e", EntityType.DEVICE, "Device", {}), 1.0, {}
         ).to_dict()["content_preview"] is None
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (search.py:28): SearchResult.to_dict does `self.entity.entity_type.value` "
-            "unguarded, so it raises AttributeError when entity_type is a plain string. "
-            "Entity.to_dict (entity.py:103) and EntityRelationship.to_dict "
-            "(relationship.py:106) both defend against exactly this with hasattr/getattr, "
-            "so a string-valued entity serializes everywhere except here. Directly "
-            "relevant to the strings-for-enums refactor."
-        ),
-    )
     def test_to_dict_accepts_a_string_entity_type(self):
         entity = Entity(
             id="e",

--- a/inbetweenies/tests/unit/test_graph_traversal.py
+++ b/inbetweenies/tests/unit/test_graph_traversal.py
@@ -1,8 +1,10 @@
 """Test GraphTraversal algorithms (inbetweenies/graph/traversal.py).
 
-Traversal follows *outgoing* edges (``from`` -> ``to``) except for
-``get_ancestors``, which follows incoming ones. The house fixture's edges are
-laid out in `memory_graph.build_house`; the ids below refer to it.
+Traversal follows *outgoing* edges (``from`` -> ``to``) except for the
+hierarchy pair, ``get_ancestors``/``get_descendants``, whose direction depends
+on the relationship type being walked (see ``TestAncestorsAndDescendants``).
+The house fixture's edges are laid out in `memory_graph.build_house`; the ids
+below refer to it.
 """
 
 import pytest
@@ -33,6 +35,18 @@ def control_chain():
         graph.add_entity(make_entity(node, EntityType.DEVICE, f"Device {node}"))
     graph.connect("c1-c2", "c1", "c2", RelationshipType.CONTROLS)
     graph.connect("c2-c3", "c2", "c3", RelationshipType.CONTROLS)
+    return graph
+
+
+@pytest.fixture
+def part_of_chain():
+    """dev PART_OF zone PART_OF home -- a child->parent chain, as the schema stores it."""
+    graph = InMemoryGraph()
+    graph.add_entity(make_entity("home", EntityType.HOME, "Home"))
+    graph.add_entity(make_entity("zone", EntityType.ZONE, "Upstairs"))
+    graph.add_entity(make_entity("dev", EntityType.DEVICE, "Sensor"))
+    graph.connect("z-h", "zone", "home", RelationshipType.PART_OF)
+    graph.connect("d-z", "dev", "zone", RelationshipType.PART_OF)
     return graph
 
 
@@ -272,28 +286,57 @@ class TestFindAllPaths:
 
 
 class TestAncestorsAndDescendants:
-    """Hierarchy walks over a parent -> child relationship type.
+    """Hierarchy walks over a single relationship type.
 
-    CONTROLS points from controller to controlled, i.e. parent -> child, which
-    is the direction this pair of methods assumes. See
-    ``test_get_ancestors_follows_part_of_the_wrong_way`` for the case where the
-    schema's own edge direction is the other way round.
+    "Above" is defined by the schema rather than by a fixed edge direction.
+    ``EntityRelationship.is_valid_for_entities`` stores PART_OF and LOCATED_IN
+    child -> parent (DEVICE->ZONE, ROOM->HOME), so ancestors are reached by
+    following those edges forwards; CONTROLS is stored controller -> controlled,
+    so ancestors are reached by following it backwards. The set of upward types
+    is ``inbetweenies.graph.traversal.CHILD_TO_PARENT_TYPES``.
     """
 
-    async def test_get_ancestors_walks_incoming_edges_transitively(self, control_chain):
+    async def test_get_ancestors_of_a_parent_to_child_type_walks_incoming_edges(
+        self, control_chain
+    ):
         ancestors = await control_chain.get_ancestors("c3", RelationshipType.CONTROLS)
 
         assert [e.id for e in ancestors] == ["c2", "c1"]
 
+    async def test_get_ancestors_of_a_child_to_parent_type_walks_outgoing_edges(
+        self, part_of_chain
+    ):
+        # dev -> zone -> home is how the schema stores containment, so a leaf's
+        # ancestors are found by following its own outgoing edges.
+        ancestors = await part_of_chain.get_ancestors("dev", RelationshipType.PART_OF)
+
+        assert [e.id for e in ancestors] == ["zone", "home"]
+
     async def test_get_ancestors_of_root_is_empty(self, control_chain):
         assert await control_chain.get_ancestors("c1", RelationshipType.CONTROLS) == []
 
+    async def test_get_ancestors_of_part_of_root_is_empty(self, part_of_chain):
+        assert await part_of_chain.get_ancestors("home", RelationshipType.PART_OF) == []
+
+    async def test_get_ancestors_excludes_the_starting_entity(self, cycle_graph):
+        # In a cycle every node is reachable from itself; it is still not its
+        # own ancestor.
+        ancestors = await cycle_graph.get_ancestors("a", RelationshipType.CONTROLS)
+
+        assert "a" not in [e.id for e in ancestors]
+
     async def test_get_ancestors_respects_max_depth(self, control_chain):
         ancestors = await control_chain.get_ancestors(
-            "c3", RelationshipType.CONTROLS, max_depth=0
+            "c3", RelationshipType.CONTROLS, max_depth=1
         )
 
         assert [e.id for e in ancestors] == ["c2"]
+
+    async def test_get_ancestors_max_depth_zero_returns_nothing(self, control_chain):
+        # max_depth counts hops, as in bfs(): zero hops reaches no one.
+        assert await control_chain.get_ancestors(
+            "c3", RelationshipType.CONTROLS, max_depth=0
+        ) == []
 
     async def test_get_ancestors_ignores_other_relationship_types(self, house):
         # device-light's incoming edges include AUTOMATES and PROCEDURE_FOR;
@@ -326,51 +369,86 @@ class TestAncestorsAndDescendants:
         assert "c3" not in ids
 
     async def test_get_descendants_ignores_other_relationship_types(self, cycle_graph):
+        # "a" is LOCATED_IN "room", i.e. the room is the parent, so the walk
+        # down from the room reaches "a". The CONTROLS edges out of "a" are a
+        # different type and must not be followed.
         ids = {
             e.id
-            for e in await cycle_graph.get_descendants("a", RelationshipType.LOCATED_IN)
+            for e in await cycle_graph.get_descendants("room", RelationshipType.LOCATED_IN)
         }
 
-        assert "room" in ids
-        assert "b" not in ids
+        assert ids == {"a"}
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (traversal.py:190-229 / 231-253): get_ancestors and get_descendants "
-            "assume edges point parent->child, but the schema's hierarchy edges point "
-            "child->parent (relationship.py:147-151 validates PART_OF only as "
-            "ROOM->HOME, ZONE->HOME, DEVICE->ZONE). get_ancestors follows *incoming* "
-            "edges and calls rel.from_entity_id the 'parent', so for the PART_OF "
-            "example named in its own docstring it walks downwards and returns "
-            "nothing for a leaf."
-        ),
-    )
-    async def test_get_ancestors_follows_part_of_the_wrong_way(self):
-        graph = InMemoryGraph()
-        graph.add_entity(make_entity("home", EntityType.HOME, "Home"))
-        graph.add_entity(make_entity("zone", EntityType.ZONE, "Upstairs"))
-        graph.add_entity(make_entity("dev", EntityType.DEVICE, "Sensor"))
-        graph.connect("z-h", "zone", "home", RelationshipType.PART_OF)
-        graph.connect("d-z", "dev", "zone", RelationshipType.PART_OF)
+    async def test_get_descendants_of_a_child_to_parent_type_walks_incoming_edges(
+        self, part_of_chain
+    ):
+        descendants = await part_of_chain.get_descendants("home", RelationshipType.PART_OF)
 
-        ancestors = await graph.get_ancestors("dev", RelationshipType.PART_OF)
+        assert [e.id for e in descendants] == ["zone", "dev"]
 
-        assert [e.id for e in ancestors] == ["zone", "home"]
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (traversal.py:249-253): get_descendants delegates to bfs(), which "
-            "includes the starting entity in its result, so an entity is reported as "
-            "its own descendant. get_ancestors excludes self, so the two are "
-            "asymmetric."
-        ),
-    )
     async def test_get_descendants_excludes_the_starting_entity(self, control_chain):
         descendants = await control_chain.get_descendants("c1", RelationshipType.CONTROLS)
 
         assert [e.id for e in descendants] == ["c2", "c3"]
+
+    async def test_get_descendants_excludes_the_starting_entity_in_a_cycle(self, cycle_graph):
+        descendants = await cycle_graph.get_descendants("a", RelationshipType.CONTROLS)
+
+        assert [e.id for e in descendants] == ["b", "c"]
+
+    async def test_get_descendants_max_depth_zero_returns_nothing(self, control_chain):
+        assert await control_chain.get_descendants(
+            "c1", RelationshipType.CONTROLS, max_depth=0
+        ) == []
+
+    async def test_get_descendants_skips_dangling_edges(self, control_chain):
+        control_chain.connect("c1-ghost", "c1", "ghost", RelationshipType.CONTROLS)
+
+        descendants = await control_chain.get_descendants("c1", RelationshipType.CONTROLS)
+
+        assert [e.id for e in descendants] == ["c2", "c3"]
+
+    @pytest.mark.parametrize(
+        "rel_type,pairs",
+        [
+            # (ancestor, descendant) pairs in each fixture's hierarchy.
+            (RelationshipType.CONTROLS, [("c1", "c2"), ("c1", "c3"), ("c2", "c3")]),
+            (RelationshipType.PART_OF, [("zone", "dev"), ("home", "zone"), ("home", "dev")]),
+        ],
+    )
+    async def test_ancestors_and_descendants_are_exact_inverses(
+        self, control_chain, part_of_chain, rel_type, pairs
+    ):
+        graph = control_chain if rel_type is RelationshipType.CONTROLS else part_of_chain
+
+        for above, below in pairs:
+            assert above in [e.id for e in await graph.get_ancestors(below, rel_type)]
+            assert below in [e.id for e in await graph.get_descendants(above, rel_type)]
+            # ...and not the other way round.
+            assert below not in [e.id for e in await graph.get_ancestors(above, rel_type)]
+            assert above not in [e.id for e in await graph.get_descendants(below, rel_type)]
+
+    @pytest.mark.parametrize("max_depth", [0, 1, 2, 3, None])
+    async def test_max_depth_means_the_same_hop_count_in_both_directions(
+        self, control_chain, max_depth
+    ):
+        # c1 -> c2 -> c3: whatever depth bound reaches c3 from c1 downwards
+        # must reach c1 from c3 upwards.
+        down = [
+            e.id
+            for e in await control_chain.get_descendants(
+                "c1", RelationshipType.CONTROLS, max_depth=max_depth
+            )
+        ]
+        up = [
+            e.id
+            for e in await control_chain.get_ancestors(
+                "c3", RelationshipType.CONTROLS, max_depth=max_depth
+            )
+        ]
+
+        assert len(down) == len(up)
+        assert ("c3" in down) == ("c1" in up)
 
 
 class TestDetectCycles:
@@ -404,18 +482,33 @@ class TestDetectCycles:
     async def test_unknown_start_reports_no_cycles(self, house):
         assert await house.detect_cycles(start_id="no-such-entity") == []
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "BUG (traversal.py:299-304): detect_cycles(start_id=None) is documented as "
-            "'if None, check entire graph' but the else branch is a bare `pass`, so it "
-            "silently reports no cycles for a graph that has one. Either the docstring "
-            "or the implementation is wrong; a caller cannot tell a clean graph from an "
-            "unimplemented scan."
-        ),
-    )
     async def test_whole_graph_scan_finds_cycles(self, cycle_graph):
         assert await cycle_graph.detect_cycles() == [["a", "b", "c", "a"]]
+
+    async def test_whole_graph_scan_finds_a_cycle_no_single_start_reaches(self):
+        # Two disconnected components: an acyclic one that is scanned first,
+        # and a cyclic one that nothing in the first can reach.
+        graph = InMemoryGraph()
+        for node in ("solo", "sink", "m", "n"):
+            graph.add_entity(make_entity(node, EntityType.DEVICE, node.upper()))
+        graph.connect("solo-sink", "solo", "sink", RelationshipType.CONTROLS)
+        graph.connect("mn", "m", "n", RelationshipType.CONTROLS)
+        graph.connect("nm", "n", "m", RelationshipType.CONTROLS)
+
+        assert await graph.detect_cycles(start_id="solo") == []
+        assert await graph.detect_cycles() == [["m", "n", "m"]]
+
+    async def test_whole_graph_scan_of_an_acyclic_graph_reports_nothing(self, house):
+        assert await house.detect_cycles() == []
+
+    async def test_whole_graph_scan_on_an_empty_graph_reports_nothing(self, empty_graph):
+        assert await empty_graph.detect_cycles() == []
+
+    async def test_whole_graph_scan_respects_the_relationship_type_filter(self, cycle_graph):
+        assert await cycle_graph.detect_cycles(rel_types=[RelationshipType.LOCATED_IN]) == []
+        assert await cycle_graph.detect_cycles(rel_types=[RelationshipType.CONTROLS]) == [
+            ["a", "b", "c", "a"]
+        ]
 
 
 class TestCentrality:


### PR DESCRIPTION
Clears the tracked follow-ups from Stages A and B. **751 → 798 tests, zero xfail, zero failures.**

## Shared core — the 7 pinned bugs, fixed at source

The interesting one was `get_ancestors`/`get_descendants`, which needed a **contract** rather than a patch. A single global edge direction cannot satisfy the schema: `is_valid_for_entities` validates `LOCATED_IN` as DEVICE→ROOM→ZONE→HOME and `PART_OF` as ROOM→HOME (child→parent), while `CONTROLS` is controller→controlled. The graph stores two conventions, so direction is now type-aware and both methods share one walk — exact inverses by construction.

**Three previously-passing tests had to change.** The notable one asserted `get_descendants("a", LOCATED_IN)` contains `"room"` — but `a LOCATED_IN room` means the room is a's *parent*. That test encoded the same inversion as the bug sitting next to it, and passed.

Also: `create_new_version` mutated the caller's dict, `get_subgraph` honoured only `rel_types[0]` and double-counted edges, `SearchResult.to_dict` had the unguarded `.value`, and `detect_cycles(None)` was a bare `pass` reporting cyclic graphs clean.

## Client graph-store collision

Stores were keyed on the db file's **parent directory**, so two clients with different databases in one directory shared one graph and one pending set — either could clear the other's unpushed marks. Now `<db_path>.graph/`, keyed on the whole filename (`client.db` and `client.sqlite` share a stem, so a stem-based name would collide again).

**Migration adopts automatically only where ownership isn't in question.** One db in the directory → the shared store can only have been written by it, so adopt. Two or more → decline loudly and leave it, because adopting would import a stranger's entities and push them to the server under this client's identity. Copies rather than moves, and stamps a marker.

`clear_graph_data()` was wiping every neighbour's entities and dropping their unpushed changes; now scoped to its own store. `_save_data` writes via temp-file + `os.replace`, closing the window that produced the observed `JSONDecodeError`.

## The suite is re-entrant again

Every integration test used `NamedTemporaryFile`, so the whole suite shared one `$TMPDIR` store across tests, runs, *and concurrent processes* — I'd hit this myself as six spurious errors. A stale pending entry from an earlier run was found sitting in it.

Fixing that exposed a second one: `blowing-off connect` writes `.blowingoff.json` into the **CWD**, so tests were writing into the checkout and `test_disconnect_command` only passed because `test_connect_command` had left the file there — while asserting against a path `disconnect` never reads.

Verified: two concurrent `blowing-off` suites both green (233 each), shared `$TMPDIR` store no longer created.

Follow-up filed: root `tests/test_shared_mcp.py` still leaves per-run store directories behind — accumulation, not corruption, now that they're unique.