### PR TITLE
feat: Stage C — access layer (ADR-002), atomic pushes, convergence digest

### DIFF
--- a/funkygibbon/api/sync.py
+++ b/funkygibbon/api/sync.py
@@ -5,6 +5,7 @@ Handles sync requests, conflict resolution, and delta synchronization
 between FunkyGibbon server and clients.
 """
 
+import hashlib
 import logging
 from typing import List, Dict, Optional
 from datetime import datetime, timezone
@@ -26,6 +27,10 @@ from inbetweenies.sync import (
 
 # Router
 logger = logging.getLogger(__name__)
+
+# ADR-002 §4. Sized so a first full sync of a house-scale graph is one or two
+# pages rather than one unbounded body; the loop is what matters, not the number.
+PAGE_SIZE = 500
 
 router = APIRouter(prefix="/api/v1/sync", tags=["sync"])
 
@@ -120,15 +125,7 @@ class SyncHandler:
         server_time = datetime.now(timezone.utc)
 
         # --- Compute outgoing (server -> client) changes ---
-        latest = await self._latest_entities()
-        entities = list(latest.values())
-
-        if request.sync_type == "delta":
-            since = _to_utc(request.filters.since) if (request.filters and request.filters.since) else None
-            if since is not None:
-                # Strictly greater than `since` (exclusive lower bound, §4).
-                entities = [e for e in entities
-                            if (_to_utc(e.updated_at) or datetime.min.replace(tzinfo=timezone.utc)) > since]
+        entities = await self._outgoing_entities(request)
 
         # Filters (apply to both full and delta).
         if request.filters:
@@ -138,6 +135,16 @@ class SyncHandler:
             if request.filters.modified_by:
                 wanted_users = set(request.filters.modified_by)
                 entities = [e for e in entities if e.user_id in wanted_users]
+
+        # ADR-002 §4: cap the page and hand back a resume point. Responses were
+        # unbounded — a first full sync returned the entire graph in one body.
+        # `cursor` is the highest server_seq in this page; the client loops
+        # until it comes back null.
+        more_remain = len(entities) > PAGE_SIZE
+        entities = entities[:PAGE_SIZE]
+        cursor = None
+        if more_remain and entities:
+            cursor = str(max(e.server_seq or 0 for e in entities))
 
         response_changes = []
         for entity in entities:
@@ -157,6 +164,8 @@ class SyncHandler:
             applied_relationships=applied_relationships,
             vector_clock=request.vector_clock,  # RESERVED — echoed, never read
             server_time=server_time.isoformat(),
+            cursor=cursor,
+            state_digest=await self._state_digest(),
             sync_stats=SyncStats(
                 # Counts stay consistent with the acknowledgement lists: they
                 # report what landed, not what was merely attempted.
@@ -166,6 +175,65 @@ class SyncHandler:
                 duration_ms=duration_ms,
             ),
         )
+
+    async def _outgoing_entities(self, request: SyncRequest) -> List[Entity]:
+        """The current rows this request should receive, in replication order.
+
+        Two delta mechanisms, deliberately:
+
+        * `cursor` — a server_seq watermark. Exact, clock-independent, and the
+          only one that can paginate, since it defines a total order over rows.
+        * `filters.since` — the original wall-clock bound, kept working because
+          KittenKong and blowing-off both persist `server_time` today
+          (PROTOCOL.md §4). Breaking it would strand a live client mid-upgrade.
+
+        A client sending both gets the cursor: it is the stronger statement, and
+        `updated_at` cannot separate rows written in the same microsecond.
+        """
+        stmt = select(Entity).where(Entity.is_latest.is_(True))
+
+        if request.sync_type == "delta":
+            if request.cursor:
+                try:
+                    stmt = stmt.where(Entity.server_seq > int(request.cursor))
+                except ValueError:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"cursor must be a server_seq integer, got {request.cursor!r}",
+                    )
+            elif request.filters and request.filters.since:
+                since = _to_utc(request.filters.since)
+                # Strictly greater than `since` (exclusive lower bound, §4).
+                stmt = stmt.where(Entity.updated_at > since)
+
+        # Ordered by the replication axis so paging is stable: without this the
+        # page boundary is whatever order the database happened to return, and a
+        # row can be skipped or repeated across pages.
+        stmt = stmt.order_by(Entity.server_seq)
+        result = await self.db_session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def _state_digest(self) -> str:
+        """sha256 over the sorted (id, version) set of every current row.
+
+        ADR-011 §4. Divergence between a server and a replica is otherwise
+        undetectable: both sides believe they are in sync, because both applied
+        every change they were told about. A client compares this against the
+        same computation over its own cache and resyncs on mismatch.
+
+        Deliberately the degenerate form of the Merkle tree in the deleted sync
+        stack: at this scale one hash over the id/version pairs delivers the
+        verification value, and a tree would be machinery without a payload.
+        """
+        result = await self.db_session.execute(
+            select(Entity.id, Entity.version)
+            .where(Entity.is_latest.is_(True))
+            .order_by(Entity.id)
+        )
+        digest = hashlib.sha256()
+        for entity_id, version in result.all():
+            digest.update(f"{entity_id}\x1f{version}\x1e".encode())
+        return digest.hexdigest()
 
     async def _latest_entities(self) -> Dict[str, Entity]:
         """Return the current row per entity id, read from is_latest (ADR-002 §1).
@@ -271,8 +339,10 @@ class SyncHandler:
         if not change.entity:
             return False  # relationships-only change; nothing to apply here
 
-        latest = await self._latest_entities()
-        existing = latest.get(change.entity.id)
+        # ADR-002 §3: resolve THIS id, not the whole table. Scanning every
+        # version of every entity once per pushed change is what made a
+        # 50-change push cost O(history x changes).
+        existing = await self._current_row(change.entity.id)
 
         if existing is None:
             await self._insert_version(change)
@@ -371,8 +441,10 @@ class SyncHandler:
         """
         if not change.entity:
             return False
-        latest = await self._latest_entities()
-        existing = latest.get(change.entity.id)
+        # ADR-002 §3: resolve THIS id, not the whole table. Scanning every
+        # version of every entity once per pushed change is what made a
+        # 50-change push cost O(history x changes).
+        existing = await self._current_row(change.entity.id)
         if existing is None:
             return True  # nothing to delete - the desired state already holds
         if bool((existing.content or {}).get("deleted")):

--- a/funkygibbon/api/sync.py
+++ b/funkygibbon/api/sync.py
@@ -9,7 +9,7 @@ import logging
 from typing import List, Dict, Optional
 from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from funkygibbon.database import get_db
@@ -91,6 +91,18 @@ class SyncHandler:
                     if relationship.id not in applied_relationships:
                         applied_relationships.append(relationship.id)
 
+        # ADR-011 §3: ONE transaction for the whole push. _insert_version and
+        # _persist_relationship only flush, so nothing above this line is
+        # durable yet. Committing per change — as this did — meant a crash
+        # mid-batch left the server half-updated with no record of how far it
+        # got, and the client holding acknowledgements for work that had been
+        # rolled back around it. Either the batch lands or none of it does.
+        try:
+            await self.db_session.commit()
+        except Exception:
+            await self.db_session.rollback()
+            raise
+
         # ADR-003 decision 2: sync apply is a mutation path, so it writes through
         # to the graph index in the same code path as the storage write. Without
         # this, entities arriving by sync were invisible to find_path until the
@@ -156,22 +168,73 @@ class SyncHandler:
         )
 
     async def _latest_entities(self) -> Dict[str, Entity]:
-        """Return the latest (lexically greatest version) row per entity id."""
-        result = await self.db_session.execute(select(Entity))
-        latest: Dict[str, Entity] = {}
-        for entity in result.scalars().all():
-            current = latest.get(entity.id)
-            if current is None or entity.version > current.version:
-                latest[entity.id] = entity
-        return latest
+        """Return the current row per entity id, read from is_latest (ADR-002 §1).
 
-    async def _insert_version(self, change: SyncChange, *, deleted: bool = False) -> None:
-        """Insert a new immutable version row (idempotent on (id, version))."""
+        Was `select(Entity)` — every version of every entity — reduced to
+        latest-per-id in Python, once per sync request AND once per pushed
+        change. Now the database answers the question it is asked.
+
+        This also ends the disagreement over what "latest" meant: three call
+        sites inferred it independently (lexically greatest version here,
+        greatest created_at in GraphRepository, LWW on updated_at in conflict
+        resolution), so a preserved losing version could be served as current
+        by one and not the other. Resolution now records its outcome.
+        """
+        result = await self.db_session.execute(
+            select(Entity).where(Entity.is_latest.is_(True))
+        )
+        return {entity.id: entity for entity in result.scalars().all()}
+
+    async def _current_row(self, entity_id: str) -> Optional[Entity]:
+        """The current row for one id — the push path's version of the above.
+
+        ADR-002 §3: applying a change needs the latest row for that id, not a
+        table scan. This is what made a 50-change push O(history x changes).
+        """
+        result = await self.db_session.execute(
+            select(Entity).where(Entity.id == entity_id, Entity.is_latest.is_(True))
+        )
+        return result.scalars().first()
+
+    async def _next_server_seq(self) -> int:
+        """Allocate the next replication stamp.
+
+        Gap-free and assigned in apply order, so a delta cursor is exact.
+        Wall-clock cannot do this: two rows written in the same microsecond are
+        indistinguishable to `updated_at > since`, and a clock adjustment can
+        move rows across a cursor a client has already passed.
+        """
+        result = await self.db_session.execute(select(func.max(Entity.server_seq)))
+        return (result.scalar() or 0) + 1
+
+    async def _insert_version(
+        self, change: SyncChange, *, deleted: bool = False, becomes_latest: bool = True
+    ) -> None:
+        """Insert a new immutable version row (idempotent on (id, version)).
+
+        Args:
+            becomes_latest: whether this version is the resolution winner. False
+                stores it as history — a losing version preserved per ADR-011
+                §2, which must never be served as current.
+
+        Does NOT commit: the whole push batch is one transaction (ADR-011 §3),
+        so a crash leaves nothing applied and nothing acknowledged rather than
+        a half-applied batch.
+        """
         existing_row = await self.db_session.get(
             Entity, (change.entity.id, change.entity.version)
         )
         if existing_row is not None:
             return  # already applied this exact version
+
+        if becomes_latest:
+            # Demote the incumbent in the same transaction, so there is never a
+            # moment with two current rows for one id.
+            await self.db_session.execute(
+                update(Entity)
+                .where(Entity.id == change.entity.id, Entity.is_latest.is_(True))
+                .values(is_latest=False)
+            )
 
         content = dict(change.entity.content or {})
         if deleted:
@@ -188,9 +251,11 @@ class SyncHandler:
             parent_versions=change.entity.parent_versions or [],
             created_at=now,
             updated_at=now,
+            is_latest=becomes_latest,
+            server_seq=await self._next_server_seq(),
         )
         self.db_session.add(entity)
-        await self.db_session.commit()
+        await self.db_session.flush()
 
     async def _apply_incoming(self, change: SyncChange, conflicts: List[ConflictInfo]) -> bool:
         """Apply a create/update: fast-forward if based on our latest, else resolve.
@@ -286,27 +351,15 @@ class SyncHandler:
         row is already parented into the DAG, so preserving it is one insert
         and any human can recover the content from history.
 
-        Guarded, because two rules currently disagree about which row is
-        "latest": resolution is LWW on updated_at, while _latest_entities()
-        picks the lexically greatest version string. A client edit stamped
-        after our latest's *edit* time but applied before its *insert* time
-        loses resolution yet sorts higher — inserting it would silently
-        promote the loser to the served latest. Where that holds, the insert
-        is skipped and logged rather than corrupting state; the content is
-        still reported in `conflicts`. ADR-002's is_latest column removes the
-        disagreement in Stage C, after which this guard can go.
+        Unconditional since ADR-002 §1. It used to be guarded: "latest" was
+        inferred from the version string, so a losing version that happened to
+        sort above the winner would be promoted by the very act of preserving
+        it, and such rows had to be dropped instead. is_latest records the
+        resolution outcome, so a loser can be stored as history without any
+        risk of being served — every version is preserved now, not just the
+        conveniently-sorted ones.
         """
-        if change.entity.version >= existing.version:
-            logger.warning(
-                "Not preserving losing version %s for entity %s: it sorts at or "
-                "above the winning version %s, so storing it would make the loser "
-                "the served latest. Content is reported in conflicts only. "
-                "Resolved by ADR-002 is_latest (Stage C).",
-                change.entity.version, change.entity.id, existing.version,
-            )
-            return
-
-        await self._insert_version(change)
+        await self._insert_version(change, becomes_latest=False)
 
     async def _handle_delete(self, change: SyncChange) -> bool:
         """Apply a delete as a tombstone version (content.deleted = true, §8).
@@ -387,7 +440,9 @@ class SyncHandler:
             existing.user_id = user_id
             existing.updated_at = now
 
-        await self.db_session.commit()
+        # Flush, not commit: this row belongs to the batch transaction opened
+        # by handle_sync_request (ADR-011 §3).
+        await self.db_session.flush()
         return True
 
     def _entity_to_change(self, entity: Entity) -> EntityChange:

--- a/funkygibbon/graph/index_service.py
+++ b/funkygibbon/graph/index_service.py
@@ -30,9 +30,9 @@ with an application-owned service:
 
 STAGE-C NOTE ON THE GENERATION MARKER
 -------------------------------------
-ADR-003 decision 3 specifies the ADR-002 ``server_seq`` as the generation tag.
-``server_seq`` does not exist yet (it lands in Stage C), so the stand-in below
-is ``StorageMarker``: row counts plus ``max(updated_at)`` for entities and
+ADR-003 decision 3 specifies the ADR-002 ``server_seq`` as the generation tag,
+and since Stage C that is what ``StorageMarker`` carries: ``max(server_seq)``
+for entities, plus row count and ``max(updated_at)`` for
 relationships, which is one cheap aggregate query per table and is enough to
 notice any insert, update or tombstone. When ADR-002 lands, replace
 ``StorageMarker``/``_read_marker`` with a single ``max(server_seq)`` read and
@@ -109,33 +109,38 @@ def assert_single_worker_posture() -> None:
 
 @dataclass(frozen=True)
 class StorageMarker:
-    """Cheap fingerprint of graph storage.
+    """Generation tag for the index: ADR-002's ``server_seq`` (ADR-003 §3).
 
-    Stand-in for ADR-002's ``server_seq`` (see module docstring). Equality is the
-    only operation used: any insert, in-place update or tombstone changes either
-    a row count or a ``max(updated_at)``.
+    ``max(server_seq)`` is the generation the index was built at. It is
+    monotonic and assigned in apply order, so a single integer comparison
+    answers "has anything been written since?".
+
+    This replaces a stand-in of row counts plus ``max(updated_at)``, used while
+    ``server_seq`` did not exist. That stand-in had a real blind spot: an
+    in-place update that changed neither the row count nor a timestamp within
+    the clock's resolution was invisible to it, so drift could go undetected —
+    the exact failure it exists to catch.
+
+    Relationships are not versioned and carry no ``server_seq``, so their count
+    and ``max(updated_at)`` are still the best available signal for that table.
     """
 
-    entity_rows: int
-    relationship_rows: int
-    latest_entity_update: Optional[Any] = None
+    entity_seq: Optional[int] = None
+    relationship_rows: int = 0
     latest_relationship_update: Optional[Any] = None
 
 
 async def _read_marker(db: AsyncSession) -> StorageMarker:
-    """Read the storage marker. Two aggregate queries, no row scan."""
-    entities = (
-        await db.execute(select(func.count(Entity.id), func.max(Entity.updated_at)))
-    ).one()
+    """Read the generation tag. Two aggregates, no row scan."""
+    entity_seq = (await db.execute(select(func.max(Entity.server_seq)))).scalar()
     relationships = (
         await db.execute(
             select(func.count(EntityRelationship.id), func.max(EntityRelationship.updated_at))
         )
     ).one()
     return StorageMarker(
-        entity_rows=entities[0] or 0,
+        entity_seq=entity_seq,
         relationship_rows=relationships[0] or 0,
-        latest_entity_update=_as_marker_value(entities[1]),
         latest_relationship_update=_as_marker_value(relationships[1]),
     )
 
@@ -164,8 +169,8 @@ class GraphIndexService:
         self.enabled = graph_index_enabled() if enabled is None else enabled
         self.loaded = False
         # Monotonic counter bumped on every write-through and every rebuild.
-        # Cheap observability hook (tests assert on it, logs report it) and the
-        # natural place for ADR-002's server_seq to slot in during Stage C.
+        # Purely an observability hook (tests assert on it, logs report it) —
+        # drift detection uses StorageMarker's server_seq, not this.
         self.generation = 0
         self.rebuild_count = 0
         self._marker: Optional[StorageMarker] = None

--- a/funkygibbon/migrate.py
+++ b/funkygibbon/migrate.py
@@ -213,10 +213,66 @@ def run_migration(conn: sqlite3.Connection, *, apply: bool) -> Dict[str, int]:
             f"{remaining_inline} inline photos remain"
         )
 
+    stats.update(_backfill_access_columns(cur))
+
     if apply:
         conn.commit()
     else:
         conn.rollback()
+    return stats
+
+
+def _backfill_access_columns(cur) -> Dict[str, int]:
+    """Add and populate is_latest / server_seq on an existing database (ADR-002).
+
+    Idempotent: adds each column only if absent, and recomputes the values from
+    the rows themselves, so re-running cannot corrupt an already-migrated file.
+
+    Which row is "latest" is decided here by the greatest version string. That
+    is the rule the server used before this column existed, so the backfill
+    reproduces the state the database was already being served under rather
+    than silently re-deciding history. From now on the value is written by
+    conflict resolution, which is the only place that actually knows.
+    """
+    stats = {"is_latest_set": 0, "server_seq_set": 0}
+    existing = {row[1] for row in cur.execute("PRAGMA table_info(entities)").fetchall()}
+
+    if "is_latest" not in existing:
+        cur.execute("ALTER TABLE entities ADD COLUMN is_latest BOOLEAN NOT NULL DEFAULT 1")
+    if "server_seq" not in existing:
+        cur.execute("ALTER TABLE entities ADD COLUMN server_seq INTEGER")
+
+    # is_latest: exactly one per id, the greatest version.
+    cur.execute("UPDATE entities SET is_latest = 0")
+    cur.execute("""
+        UPDATE entities SET is_latest = 1
+        WHERE (id, version) IN (SELECT id, MAX(version) FROM entities GROUP BY id)
+    """)
+    stats["is_latest_set"] = cur.execute(
+        "SELECT COUNT(*) FROM entities WHERE is_latest = 1"
+    ).fetchone()[0]
+
+    # server_seq: dense, in the closest thing to apply order we can reconstruct
+    # (created_at, then version as a tiebreak). Exact ordering of history is
+    # unrecoverable after the fact; what matters is that the stamps are unique
+    # and monotonic so a client cursor cannot skip or repeat a row.
+    rows = cur.execute(
+        "SELECT id, version FROM entities ORDER BY created_at, version"
+    ).fetchall()
+    for seq, (eid, version) in enumerate(rows, start=1):
+        cur.execute(
+            "UPDATE entities SET server_seq = ? WHERE id = ? AND version = ?",
+            (seq, eid, version),
+        )
+    stats["server_seq_set"] = len(rows)
+
+    # Indexes are created by SQLAlchemy's metadata on a fresh database; add them
+    # here for a file that predates them.
+    cur.execute("CREATE INDEX IF NOT EXISTS ix_entities_is_latest_server_seq "
+                "ON entities (is_latest, server_seq)")
+    cur.execute("CREATE INDEX IF NOT EXISTS ix_entities_server_seq ON entities (server_seq)")
+    cur.execute("CREATE INDEX IF NOT EXISTS ix_entities_id_version ON entities (id, version)")
+
     return stats
 
 

--- a/funkygibbon/repositories/graph.py
+++ b/funkygibbon/repositories/graph.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Dict, Any
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import select, and_, or_
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -31,12 +31,37 @@ class GraphRepository(BaseRepository[Entity]):
         """
         Store entity with version tracking.
 
+        Maintains is_latest and server_seq (ADR-002 §1-2), so every write path
+        keeps the invariant "exactly one current row per id" — not just the sync
+        apply path. A column that only one writer maintains is worse than no
+        column: readers trust it, and the paths that skip it leave two rows
+        claiming to be current with nothing to say which is right.
+
         Args:
             entity: Entity to store
 
         Returns:
             Stored entity
         """
+        # `is not False`, not a truth test: a freshly constructed Entity has
+        # is_latest=None until flush, because the column default is applied by
+        # the INSERT rather than by __init__. A plain `if entity.is_latest:`
+        # therefore skips the demotion for exactly the common case — a new
+        # version — and leaves two rows marked current.
+        if entity.is_latest is not False:
+            entity.is_latest = True
+            # Demote the incumbent in the same transaction as the insert.
+            await self.db.execute(
+                update(Entity)
+                .where(Entity.id == entity.id,
+                       Entity.version != entity.version,
+                       Entity.is_latest.is_(True))
+                .values(is_latest=False)
+            )
+        if entity.server_seq is None:
+            next_seq = (await self.db.execute(select(func.max(Entity.server_seq)))).scalar()
+            entity.server_seq = (next_seq or 0) + 1
+
         self.db.add(entity)
         await self.db.flush()
         return entity
@@ -58,23 +83,15 @@ class GraphRepository(BaseRepository[Entity]):
                 and_(Entity.id == entity_id, Entity.version == version)
             )
         else:
-            # Latest = greatest version string, NOT greatest created_at.
+            # ADR-002 §1: read the recorded answer.
             #
-            # Version strings carry a UTC ISO-8601 prefix, so lexical order is
-            # chronological by *edit* time. created_at is the row's *insert*
-            # time, and the two diverge whenever a version arrives out of
-            # order — which sync does routinely: an offline edit synced later,
-            # or a losing version preserved into history (ADR-011 §2). Ordering
-            # by created_at made the most recently *inserted* row win, so
-            # preserving a superseded version would silently promote it here
-            # while api/sync.py::_latest_entities() still reported the correct
-            # one. Two disagreeing definitions of "latest" over the same table.
-            #
-            # This matches _latest_entities(). ADR-002 replaces both with an
-            # is_latest column in Stage C.
+            # This has now been three rules in three commits — created_at, then
+            # the version string, now is_latest — which is the argument for the
+            # column. The first two INFERRED which version won; only conflict
+            # resolution knows, and it now writes it down.
             stmt = select(Entity).where(
-                Entity.id == entity_id
-            ).order_by(Entity.version.desc()).limit(1)
+                Entity.id == entity_id, Entity.is_latest.is_(True)
+            ).limit(1)
 
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
@@ -89,43 +106,17 @@ class GraphRepository(BaseRepository[Entity]):
         Returns:
             List of entities
         """
-        # Subquery to get latest version for each entity ID
-        subquery = (
-            select(Entity.id, Entity.version, Entity.created_at)
-            .where(Entity.entity_type == entity_type)
-            .subquery()
-        )
-
-        # Window function to rank versions by created_at
-        from sqlalchemy import func
-        ranked = (
-            select(
-                subquery.c.id,
-                subquery.c.version,
-                func.row_number().over(
-                    partition_by=subquery.c.id,
-                    order_by=subquery.c.created_at.desc()
-                ).label("rn")
-            ).subquery()
-        )
-
-        # Get only the latest version (rn=1) for each entity
-        latest_versions = (
-            select(ranked.c.id, ranked.c.version)
-            .where(ranked.c.rn == 1)
-            .subquery()
-        )
-
-        # Join with Entity table to get full entity data
+        # ADR-002 §1: is_latest, not a window function over created_at.
+        #
+        # This was the FOURTH place inferring "latest", and the last one still
+        # using created_at — the rule Stage A already had to correct in
+        # get_entity(). It matters more now than it did then: a losing version
+        # is preserved with a later created_at than the winner it lost to
+        # (ADR-011 §2), so ranking by insert time would load the LOSER into the
+        # graph index and serve it from every traversal.
         stmt = (
             select(Entity)
-            .join(
-                latest_versions,
-                and_(
-                    Entity.id == latest_versions.c.id,
-                    Entity.version == latest_versions.c.version
-                )
-            )
+            .where(Entity.entity_type == entity_type, Entity.is_latest.is_(True))
             .options(selectinload(Entity.outgoing_relationships))
             .options(selectinload(Entity.incoming_relationships))
         )

--- a/funkygibbon/tests/test_access_layer.py
+++ b/funkygibbon/tests/test_access_layer.py
@@ -234,3 +234,171 @@ class TestAtomicPushBatch:
 
         assert set(body["applied"]) == {"A", "B"}
         assert len(_rows()) == 2
+
+
+class TestPaginationAndDigest:
+    """ADR-002 §4 cursor pagination and ADR-011 §4 convergence digest."""
+
+    def _make(self, client, headers, count, prefix="P"):
+        _sync(client, headers, [
+            _change("create", id=f"{prefix}{i}", version=Entity.create_version("a"))
+            for i in range(count)
+        ])
+
+    def test_a_small_graph_fits_one_page_with_no_cursor(self, client, headers):
+        self._make(client, headers, 3)
+
+        body = _sync(client, headers).json()
+        assert len(body["changes"]) == 3
+        assert body["cursor"] is None, "nothing left to resume from"
+
+    def test_an_oversized_graph_is_capped_and_returns_a_cursor(self, client, headers, monkeypatch):
+        import funkygibbon.api.sync as syncmod
+        monkeypatch.setattr(syncmod, "PAGE_SIZE", 2)
+        self._make(client, headers, 5)
+
+        body = _sync(client, headers).json()
+        assert len(body["changes"]) == 2, "the page is capped"
+        assert body["cursor"] is not None, "and says where to resume"
+
+    def test_looping_on_the_cursor_drains_every_row_exactly_once(self, client, headers, monkeypatch):
+        """The property that matters: no row skipped, none delivered twice.
+
+        Ordering by server_seq is what makes this hold. Without a total order
+        the page boundary is whatever the database happened to return, and rows
+        fall through the gap between pages.
+        """
+        import funkygibbon.api.sync as syncmod
+        monkeypatch.setattr(syncmod, "PAGE_SIZE", 2)
+
+        # Ids deliberately sort AGAINST creation order (P6 created first, P0
+        # last). If the server paged by anything other than the replication
+        # axis, the first page would hold the highest server_seq values and the
+        # cursor would jump straight past the rest — so this fixture is what
+        # makes the test able to fail.
+        for i in reversed(range(7)):
+            _sync(client, headers,
+                  [_change("create", id=f"P{i}", version=Entity.create_version("a"))])
+
+        seen, cursor, pages = [], None, 0
+        while True:
+            body = client.post("/api/v1/sync/", headers=headers, json={
+                "protocol_version": "inbetweenies-v2", "device_id": "d",
+                "user_id": USER, "sync_type": "delta", "changes": [],
+                "cursor": cursor,
+            }).json()
+            seen += [c["entity"]["id"] for c in body["changes"] if c.get("entity")]
+            cursor = body["cursor"]
+            pages += 1
+            if cursor is None or pages > 20:
+                break
+
+        assert pages > 1, "the fixture must actually span multiple pages"
+        assert len(seen) == len(set(seen)), "no row delivered twice"
+        assert set(seen) == {f"P{i}" for i in range(7)}, "no row skipped"
+
+    def test_a_non_numeric_cursor_is_rejected(self, client, headers):
+        """Better a 400 than silently returning the whole graph."""
+        response = client.post("/api/v1/sync/", headers=headers, json={
+            "protocol_version": "inbetweenies-v2", "device_id": "d", "user_id": USER,
+            "sync_type": "delta", "changes": [], "cursor": "not-a-number",
+        })
+
+        assert response.status_code == 400
+
+    def test_the_legacy_timestamp_delta_still_works(self, client, headers):
+        """KittenKong and blowing-off both persist server_time today. Breaking
+        `filters.since` would strand a live client mid-upgrade."""
+        watermark = _sync(client, headers).json()["server_time"]
+        self._make(client, headers, 1, prefix="AFTER")
+
+        body = client.post("/api/v1/sync/", headers=headers, json={
+            "protocol_version": "inbetweenies-v2", "device_id": "d", "user_id": USER,
+            "sync_type": "delta", "changes": [], "filters": {"since": watermark},
+        }).json()
+
+        ids = {c["entity"]["id"] for c in body["changes"] if c.get("entity")}
+        assert "AFTER0" in ids
+
+    def test_the_digest_ignores_superseded_versions(self, client, headers):
+        """It covers current state, so history must not move it — otherwise two
+        replicas that agree on the present would report divergence."""
+        v1 = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=v1)])
+        with_one_version = _sync(client, headers).json()["state_digest"]
+
+        _sync(client, headers,
+              [_change("update", id="E", version=_ANCIENT, parents=[])])
+        after_a_loser = _sync(client, headers).json()["state_digest"]
+
+        assert after_a_loser == with_one_version, (
+            "storing a losing version changes history, not current state"
+        )
+
+
+class TestEveryWritePathMaintainsIsLatest:
+    """A column only one writer maintains is worse than no column.
+
+    Readers trust it, and the paths that skip it leave two rows both claiming
+    to be current with nothing to say which is right. That is not theoretical:
+    routing the graph index at is_latest immediately exposed the repository
+    write path as not maintaining it.
+    """
+
+    def test_the_repository_demotes_the_previous_version(self, client, headers):
+        """A freshly built Entity has is_latest=None until flush — the column
+        default is applied by the INSERT, not by __init__. A truth test on it
+        silently skips the demotion for the commonest case."""
+        import asyncio as _asyncio
+        from funkygibbon.repositories.graph import GraphRepository
+        from inbetweenies.models import EntityType, SourceType
+
+        def _store(name, version, entity_id):
+            async def _run():
+                async with dbmod.async_session() as session:
+                    stored = await GraphRepository(session).store_entity(Entity(
+                        id=entity_id, version=version, entity_type=EntityType.DEVICE,
+                        name=name, content={}, source_type=SourceType.MANUAL,
+                        user_id=USER, parent_versions=[],
+                    ))
+                    await session.commit()
+                    return stored
+            return _asyncio.run(_run())
+
+        v1 = Entity.create_version("a")
+        _store("first", v1, "R1")
+        v2 = Entity.create_version("b")
+        _store("second", v2, "R1")
+
+        rows = {r.version: r.is_latest for r in _rows("R1")}
+        assert rows == {v1: False, v2: True}
+
+    def test_the_repository_assigns_a_server_seq(self, client, headers):
+        import asyncio as _asyncio
+        from funkygibbon.repositories.graph import GraphRepository
+        from inbetweenies.models import EntityType, SourceType
+
+        async def _run():
+            async with dbmod.async_session() as session:
+                await GraphRepository(session).store_entity(Entity(
+                    id="R2", version=Entity.create_version("a"),
+                    entity_type=EntityType.DEVICE, name="n", content={},
+                    source_type=SourceType.MANUAL, user_id=USER, parent_versions=[],
+                ))
+                await session.commit()
+        _asyncio.run(_run())
+
+        assert _rows("R2")[0].server_seq is not None
+
+    def test_rest_and_sync_writes_share_one_sequence(self, client, headers):
+        """Two writers allocating stamps independently would collide, and a
+        client cursor would then skip whichever lost."""
+        client.post("/api/v1/graph/entities", headers=headers, json={
+            "entity_type": "device", "name": "via-rest", "content": {},
+            "source_type": "manual", "user_id": USER,
+        })
+        _sync(client, headers, [_change("create", id="VIA-SYNC",
+                                        version=Entity.create_version("a"))])
+
+        seqs = [r.server_seq for r in _rows()]
+        assert len(seqs) == len(set(seqs)), "stamps must be unique across writers"

--- a/funkygibbon/tests/test_access_layer.py
+++ b/funkygibbon/tests/test_access_layer.py
@@ -1,0 +1,236 @@
+"""ADR-002 access layer + ADR-011 §3 atomic batches.
+
+`is_latest` and `server_seq` are not primarily optimisations at this data size
+(the live instance is ~500 version rows). They are here because they make two
+things FACTS rather than inferences:
+
+* **Which version is current.** Three call sites used to infer it and disagree:
+  sync took the lexically greatest version, GraphRepository took the greatest
+  created_at, and conflict resolution decided by LWW on updated_at. A preserved
+  losing version could therefore be served as current by the REST API while
+  sync correctly reported the winner. Resolution now records its outcome.
+* **What order the server applied things in.** `updated_at > since` cannot
+  separate two rows written in the same microsecond, and a clock adjustment can
+  move rows across a cursor a client has already passed.
+
+The scalability follows, but the correctness is the reason.
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+from fastapi.testclient import TestClient
+
+import funkygibbon.database as dbmod
+from funkygibbon.api.app import create_app
+from funkygibbon.config import settings
+from inbetweenies.models import Entity
+
+USER = "access-layer"
+_ANCIENT = "2020-01-01T00:00:00.000000+00:00-000001-old"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "funkygibbon.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    engine = create_async_engine(url, connect_args={"timeout": 5}, poolclass=NullPool)
+    sm = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(dbmod, "engine", engine)
+    monkeypatch.setattr(dbmod, "async_session", sm)
+    monkeypatch.setattr(settings, "database_url", url)
+    monkeypatch.chdir(tmp_path)
+    yield
+    asyncio.run(engine.dispose())
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr(settings, "backup_schedule_enabled", False)
+    with TestClient(create_app()) as c:
+        yield c
+
+
+@pytest.fixture
+def headers(client):
+    token = client.post(
+        "/api/v1/auth/admin/login", json={"password": "admin"}
+    ).json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _change(change_type, *, id, version, name="N", parents=None, rels=None):
+    return {
+        "change_type": change_type,
+        "entity": {
+            "id": id, "version": version, "entity_type": "device", "name": name,
+            "content": {}, "source_type": "manual", "user_id": USER,
+            "parent_versions": parents or [],
+        },
+        "relationships": rels or [],
+    }
+
+
+def _sync(client, headers, changes=None, sync_type="full"):
+    return client.post("/api/v1/sync/", headers=headers, json={
+        "protocol_version": "inbetweenies-v2", "device_id": "d", "user_id": USER,
+        "sync_type": sync_type, "changes": changes or [],
+    })
+
+
+def _rows(entity_id=None):
+    async def _read():
+        async with dbmod.async_session() as session:
+            stmt = select(Entity)
+            if entity_id is not None:
+                stmt = stmt.where(Entity.id == entity_id)
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+    return asyncio.run(_read())
+
+
+class TestIsLatest:
+    """Exactly one current row per id, and it is the one resolution chose."""
+
+    def test_a_new_version_demotes_its_predecessor(self, client, headers):
+        v1 = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=v1)])
+        v2 = Entity.create_version("b")
+        _sync(client, headers, [_change("update", id="E", version=v2, parents=[v1])])
+
+        latest = [r for r in _rows("E") if r.is_latest]
+        assert len(latest) == 1
+        assert latest[0].version == v2
+
+    def test_exactly_one_current_row_survives_a_long_chain(self, client, headers):
+        previous = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=previous)])
+        for _ in range(5):
+            nxt = Entity.create_version("a")
+            _sync(client, headers,
+                  [_change("update", id="E", version=nxt, parents=[previous])])
+            previous = nxt
+
+        rows = _rows("E")
+        assert len(rows) == 6, "every version is retained"
+        assert sum(1 for r in rows if r.is_latest) == 1
+
+    def test_a_losing_version_is_stored_but_not_current(self, client, headers):
+        """The bug is_latest exists to prevent: a preserved loser being served."""
+        winner = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=winner, name="kept")])
+        _sync(client, headers,
+              [_change("update", id="E", version=_ANCIENT, name="lost", parents=[])])
+
+        rows = {r.version: r for r in _rows("E")}
+        assert _ANCIENT in rows, "the loser must be preserved (ADR-011 §2)"
+        assert rows[_ANCIENT].is_latest is False
+        assert rows[winner].is_latest is True
+
+    def test_the_served_entity_is_the_current_row(self, client, headers):
+        """REST and sync must agree, which was the original defect."""
+        winner = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=winner, name="kept")])
+        _sync(client, headers,
+              [_change("update", id="E", version=_ANCIENT, name="lost", parents=[])])
+
+        served = _sync(client, headers).json()["changes"]
+        by_id = {c["entity"]["id"]: c["entity"] for c in served if c.get("entity")}
+        assert by_id["E"]["name"] == "kept"
+
+        rest = client.get(f"/api/v1/graph/entities/E", headers=headers)
+        assert rest.status_code == 200
+        assert rest.json()["entity"]["name"] == "kept", (
+            "the REST API and sync must serve the same version"
+        )
+
+    def test_a_tombstone_becomes_the_current_row(self, client, headers):
+        v1 = Entity.create_version("a")
+        _sync(client, headers, [_change("create", id="E", version=v1)])
+        v2 = Entity.create_version("b")
+        _sync(client, headers, [_change("delete", id="E", version=v2, parents=[v1])])
+
+        latest = [r for r in _rows("E") if r.is_latest]
+        assert len(latest) == 1
+        assert latest[0].content.get("deleted") is True
+
+
+class TestServerSeq:
+    """A gap-free stamp in apply order — the replication axis."""
+
+    def test_every_stored_version_gets_a_stamp(self, client, headers):
+        _sync(client, headers, [
+            _change("create", id="A", version=Entity.create_version("a")),
+            _change("create", id="B", version=Entity.create_version("b")),
+        ])
+
+        assert all(r.server_seq is not None for r in _rows())
+
+    def test_stamps_are_unique_and_ordered_by_apply_order(self, client, headers):
+        _sync(client, headers, [_change("create", id="A", version=Entity.create_version("a"))])
+        _sync(client, headers, [_change("create", id="B", version=Entity.create_version("b"))])
+
+        by_id = {r.id: r.server_seq for r in _rows()}
+        assert len({*by_id.values()}) == len(by_id), "stamps must be unique"
+        assert by_id["A"] < by_id["B"], "later apply gets a higher stamp"
+
+    def test_a_losing_version_is_also_stamped(self, client, headers):
+        """It is a stored row, so a replica must be able to receive it."""
+        _sync(client, headers, [_change("create", id="E", version=Entity.create_version("a"))])
+        _sync(client, headers,
+              [_change("update", id="E", version=_ANCIENT, parents=[])])
+
+        loser = next(r for r in _rows("E") if r.version == _ANCIENT)
+        assert loser.server_seq is not None
+
+
+class TestAtomicPushBatch:
+    """ADR-011 §3 — a push lands whole or not at all."""
+
+    def test_a_failure_mid_batch_applies_nothing(self, client, headers):
+        """The change before the failure must not survive.
+
+        Committing per change left the server half-updated with no record of
+        how far it got. An unknown relationship_type raises after the first
+        entity has been staged, which is exactly that shape.
+        """
+        good = Entity.create_version("a")
+        response = _sync(client, headers, [
+            _change("create", id="GOOD", version=good),
+            _change("create", id="BAD", version=Entity.create_version("b"), rels=[{
+                "id": "R", "from_entity_id": "BAD", "from_entity_version": "v",
+                "to_entity_id": "GOOD", "to_entity_version": good,
+                "relationship_type": "not-a-real-type", "properties": {},
+            }]),
+        ])
+
+        assert response.status_code == 400, response.text
+        assert _rows("GOOD") == [], (
+            "an entity staged before the failure must be rolled back with it"
+        )
+        assert _rows("BAD") == []
+
+    def test_nothing_is_acknowledged_when_the_batch_fails(self, client, headers):
+        """The client must retry the whole batch, so it may keep every mark."""
+        response = _sync(client, headers, [
+            _change("create", id="GOOD", version=Entity.create_version("a"), rels=[{
+                "id": "R", "from_entity_id": "GOOD", "from_entity_version": "v",
+                "to_entity_id": "GOOD", "to_entity_version": "v",
+                "relationship_type": "not-a-real-type", "properties": {},
+            }]),
+        ])
+
+        assert response.status_code == 400
+        assert "applied" not in response.json(), "a failed batch acknowledges nothing"
+
+    def test_a_successful_batch_applies_everything(self, client, headers):
+        body = _sync(client, headers, [
+            _change("create", id="A", version=Entity.create_version("a")),
+            _change("create", id="B", version=Entity.create_version("b")),
+        ]).json()
+
+        assert set(body["applied"]) == {"A", "B"}
+        assert len(_rows()) == 2

--- a/funkygibbon/tests/test_protocol_conformance.py
+++ b/funkygibbon/tests/test_protocol_conformance.py
@@ -415,13 +415,48 @@ class TestReservedFields:
 
         assert "vector_clock" in body
 
-    def test_cursor_is_absent_because_pagination_is_unimplemented(self, client, headers):
-        """§9: pinned deliberately. ADR-002 implements pagination in Stage C;
-        when it does, this test should fail and be rewritten to assert the
-        cursor contract rather than its absence."""
+    def test_cursor_is_null_when_the_stream_is_drained(self, client, headers):
+        """No longer reserved — ADR-002 §4 implemented it, as the previous
+        version of this test predicted it would.
+
+        Null means "drained", which is the client's signal to stop looping. An
+        empty `changes` list is NOT that signal: a filtered page can be empty
+        while rows remain beyond it.
+        """
+        v1 = Entity.create_version("a")
+        sync(client, headers, changes=[entity_change("create", id="E", version=v1)])
+
+        body = sync(client, headers, "full")
+        assert body.get("cursor") is None, "one small page: nothing left to resume from"
+
+    def test_a_digest_accompanies_every_response(self, client, headers):
+        """ADR-011 §4: divergence must be detectable.
+
+        Without this a client and server can both believe they are in sync
+        because both applied every change they were told about, while holding
+        different state.
+        """
         body = sync(client, headers, "full")
 
-        assert body.get("cursor") is None
+        assert body.get("state_digest"), "every response carries a state digest"
+
+    def test_the_digest_changes_when_state_changes(self, client, headers):
+        before = sync(client, headers, "full")["state_digest"]
+        sync(client, headers, changes=[
+            entity_change("create", id="NEW", version=Entity.create_version("a"))
+        ])
+        after = sync(client, headers, "full")["state_digest"]
+
+        assert before != after
+
+    def test_the_digest_is_stable_for_unchanged_state(self, client, headers):
+        """It must depend on state alone — not on time, or request order."""
+        sync(client, headers, changes=[
+            entity_change("create", id="E", version=Entity.create_version("a"))
+        ])
+
+        assert sync(client, headers, "full")["state_digest"] == \
+               sync(client, headers, "full")["state_digest"]
 
 
 # --------------------------------------------------------------------------- #

--- a/funkygibbon/tests/unit/test_graph_index_service.py
+++ b/funkygibbon/tests/unit/test_graph_index_service.py
@@ -31,7 +31,14 @@ from funkygibbon.models import (
 
 async def _store_entity(db, name, *, entity_type=EntityType.DEVICE, content=None,
                         entity_id=None, parent=None):
-    """Insert an entity version straight into storage (what sync does)."""
+    """Store an entity version the way every write path does.
+
+    Goes through GraphRepository.store_entity rather than db.add(): that is
+    where is_latest and server_seq are maintained (ADR-002 §1-2). Adding the row
+    directly leaves two versions both marked current, which is a state the
+    system cannot produce and which no reader is expected to cope with.
+    """
+    from funkygibbon.repositories.graph import GraphRepository
     entity = Entity(
         id=entity_id or str(uuid.uuid4()),
         version=Entity.create_version("test-user"),
@@ -42,9 +49,9 @@ async def _store_entity(db, name, *, entity_type=EntityType.DEVICE, content=None
         user_id="test-user",
         parent_versions=[parent] if parent else [],
     )
-    db.add(entity)
+    stored = await GraphRepository(db).store_entity(entity)
     await db.commit()
-    return entity
+    return stored
 
 
 async def _store_relationship(db, source, target,

--- a/inbetweenies/models/entity.py
+++ b/inbetweenies/models/entity.py
@@ -10,7 +10,9 @@ import re
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Any, Optional
-from sqlalchemy import Column, String, JSON, DateTime, Enum as SQLEnum
+from sqlalchemy import (
+    Boolean, Column, Index, Integer, JSON, String, DateTime, Enum as SQLEnum, text
+)
 from sqlalchemy.orm import relationship
 
 from .base import Base, InbetweeniesTimestampMixin
@@ -75,6 +77,37 @@ class Entity(Base, InbetweeniesTimestampMixin):
 
     # Version tracking for immutability
     parent_versions = Column(JSON, default=list)
+
+    # --- Server-maintained bookkeeping (ADR-002) ---------------------------
+    # Both are assigned by the server when it stores a row. Clients replicate
+    # them but never author them, and neither appears on the wire.
+    #
+    # is_latest records which version won, rather than leaving it to be
+    # re-derived. Three places used to infer it independently and disagree:
+    # api/sync.py took the lexically greatest version, GraphRepository took the
+    # greatest created_at, and conflict resolution decided by LWW on
+    # updated_at. That let a preserved losing version be served as current by
+    # the REST API while sync correctly reported the winner. A resolution
+    # outcome is a fact about a row, so it is stored on the row.
+    is_latest = Column(Boolean, nullable=False, default=True, server_default=text("1"))
+
+    # server_seq is the replication axis (ADR-004 §2): a gap-free monotonic
+    # stamp assigned in server apply order, used for delta cursors and
+    # pagination. Deliberately NOT wall-clock: `updated_at > since` cannot
+    # distinguish rows written in the same microsecond, and is hostage to clock
+    # adjustment. Queries never consult it; sync never consults client time.
+    server_seq = Column(Integer, nullable=True)
+
+    __table_args__ = (
+        # The delta scan: `where is_latest and server_seq > :cursor`.
+        Index("ix_entities_is_latest_server_seq", "is_latest", "server_seq"),
+        # `max(server_seq)` for the next stamp and for ADR-003's generation
+        # check. The composite above cannot serve this: its leading column is
+        # is_latest, so a bare server_seq aggregate would have to scan.
+        Index("ix_entities_server_seq", "server_seq"),
+        # Resolving one entity's history.
+        Index("ix_entities_id_version", "id", "version"),
+    )
 
     # Relationships defined in EntityRelationship model
     outgoing_relationships = relationship(

--- a/inbetweenies/sync/protocol.py
+++ b/inbetweenies/sync/protocol.py
@@ -89,7 +89,17 @@ class SyncResponse(BaseModel):
     changes: List[SyncChange] = Field(default_factory=list)
     conflicts: List[ConflictInfo] = Field(default_factory=list)
     vector_clock: VectorClock = Field(default_factory=VectorClock)
+    # Pagination watermark: the highest server_seq included in `changes`. Send
+    # it back as SyncRequest.cursor to resume. Null means the stream is drained
+    # — that is the signal to stop looping, not an empty `changes` list, since a
+    # filtered page can be empty while more rows remain (ADR-002 §4).
     cursor: Optional[str] = None
+    # sha256 over the sorted (id, version) set of every current row, so a client
+    # can tell whether its replica actually matches (ADR-011 §4). Divergence is
+    # otherwise undetectable: both sides believe they are in sync because both
+    # applied every change they were told about. Compared, never merged — a
+    # mismatch means resync, not a repair attempt.
+    state_digest: Optional[str] = None
     sync_stats: SyncStats = Field(default_factory=SyncStats)
     # UTC ISO-8601 server clock at response time. The client persists this and
     # sends it back as filters.since on the next delta sync (PROTOCOL.md §4).


### PR DESCRIPTION
Stage C of `docs/implementation-plan.md`. **798 → 821 tests, 0 failures**, coverage 84.6%.

## The framing changed while building it

ADR-002 is written as a scalability fix, and on that basis it wouldn't be worth doing yet — the live instance holds ~500 version rows, and `select(Entity)` over 500 rows is not a problem. Its numbers are the projected worst case at ~700× current scale.

**The actual value was correctness**, and it kept proving itself: wiring things to `is_latest` exposed *four different rules* for "which version is current", in three files.

| where | rule it used |
|---|---|
| `api/sync.py::_latest_entities` | lexically greatest version |
| `GraphRepository.get_entity` | greatest `created_at`, then version string (Stage A) |
| `GraphRepository.get_entities_by_type` | window function over `created_at` |
| conflict resolution | LWW on `updated_at` |

The third one matters most: it loads the **graph index**, and a preserved losing version has a *later* `created_at` than the winner it lost to — so it would have been indexed as current and served from every traversal. All four now read the recorded answer.

## What landed

- **`is_latest`** — resolution records its outcome. This deleted the Stage A guard that *dropped* losing versions whose version string sorted above the winner; every loser is preserved now.
- **`server_seq`** — gap-free stamp in apply order. Wall-clock can't do this: `updated_at > since` can't separate rows written in the same microsecond, and a clock adjustment moves rows across a cursor a client already passed.
- **Atomic push batches** (ADR-011 §3) — `_insert_version` committed per change. Verified by mutation: reinstating it fails the mid-batch test.
- **Pagination** — responses were unbounded. `cursor` is the resume point; null means drained.
- **`state_digest`** (ADR-011 §4) — divergence is otherwise undetectable, because both sides believe they're in sync having applied every change they were told about.
- **GraphIndex generation tag** on `server_seq`, replacing a stand-in with a real blind spot (an in-place update changing neither a row count nor a timestamp within clock resolution was invisible to it).
- **Migration**, verified against a real pre-migration database: idempotent, one current row per id, none left without one.

## Two things I got wrong and fixed

**A test that passed under the mutation it was supposed to catch.** The pagination drain test passed whether the server ordered by `server_seq` or by `id` — the ids happened to sort in creation order. Rewrote the fixture so ids sort *against* creation order; now removing the ordering fails it.

**`if entity.is_latest:` skipped the demotion for every new version.** A freshly constructed `Entity` has `is_latest=None` until flush, because the column default is applied by the INSERT, not `__init__`. Caught by an *existing* tombstone test, not by any of the ones I'd just written.

## Compatibility

`filters.since` still works — KittenKong and blowing-off both persist `server_time` today, and breaking it would strand a live client mid-upgrade. A request carrying both gets the cursor.